### PR TITLE
Refactor config package

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,41 @@ Each command accepts at least the following options:
 
 ### Config
 
-The `nerd` command uses a config file located at `~/.nerd/config.json` (location can be changed with the `--config` option) which can be used to customize nerd's behaviour.
+The `nerd` command uses a config file located at `~/.nerd/config.json` (location can be changed with the `--config-file` option) which can be used to customize nerd's behaviour.
 The structure of the config and the defaults are show below:
 ```bash
 {
         "auth": {
                 "api_endpoint": "http://auth.nerdalize.com", # URL of authentication server
-                "public_key": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEAkYbLnam4wo+heLlTZEeh1ZWsfruz9nk\nkyvc4LwKZ8pez5KYY76H1ox+AfUlWOEq+bExypcFfEIrJkf/JXa7jpzkOWBDF9Sa\nOWbQHMK+vvUXieCJvCc9Vj084ABwLBgX\n-----END PUBLIC KEY-----" # Public key used to verify JWT signature
+                "public_key": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEAkYbLnam4wo+heLlTZEeh1ZWsfruz9nk\nkyvc4LwKZ8pez5KYY76H1ox+AfUlWOEq+bExypcFfEIrJkf/JXa7jpzkOWBDF9Sa\nOWbQHMK+vvUXieCJvCc9Vj084ABwLBgX\n-----END PUBLIC KEY-----", # Public key used to verify JWT signature
+                "client_id": "GuoeRJLYOXzVa9ydPjKi83lCctWtXpNHuiy46Yux", #OAuth client ID
+                "oauth_localserver": "localhost:9876", #address of local oauth server
+                "oauth_success_url": "https://cloud.nerdalize.com" #redirect URL after successful login
         },
         "enable_logging": false, # When set to true, all output will be logged to ~/.nerd/log
-        "current_project": "", # Current project
-        "nerd_token": "", # Nerdalize JWT (can be set manually or it will be set by `nerd login`)
         "nerd_api_endpoint": "https://batch.nerdalize.com" # URL of nerdalize API (NCE)
+}
+```
+
+Session details such as OAuth session, JWT, and current project are stored in `~/.nerd/session.json` (can be changed using the `--session-file` option)
+The structure of `session.json` is show below:
+```bash
+{
+  "oauth": {
+  	"access_token": "", #oauth access token
+  	"refresh_token": "", #oauth refresh token
+  	"expiration": "", #expiration date + time
+  	"scope": "", #oauth scope
+  	"token_type": "" #Bearer
+  },
+  "jwt": {
+    "token": "", #Current JWT
+    "refresh_token": "" #used when JWT is refreshable
+  },
+  "project": {
+    "name": "", #NLZ project name
+    "aws_region": "" #AWS Region
+  }
 }
 ```
 

--- a/command/command.go
+++ b/command/command.go
@@ -16,64 +16,6 @@ import (
 
 var errShowHelp = errors.New("show error")
 
-func (cmd *command) setConfig(loc string) {
-	if loc == "" {
-		var err error
-		loc, err = conf.GetDefaultConfigLocation()
-		if err != nil {
-			fmt.Fprint(os.Stderr, errors.Wrap(err, "failed to find config location"))
-			os.Exit(-1)
-		}
-		os.MkdirAll(filepath.Dir(loc), 0755)
-		f, err := os.OpenFile(loc, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
-		if err != nil && !os.IsExist(err) {
-			fmt.Fprint(os.Stderr, errors.Wrapf(err, "failed to create config file %v", loc))
-			os.Exit(-1)
-		}
-		f.Write([]byte("{}"))
-		f.Close()
-	}
-	conf, err := conf.Read(loc)
-	if err != nil {
-		fmt.Fprint(os.Stderr, errors.Wrap(err, "failed to read config file"))
-		os.Exit(-1)
-	}
-	cmd.config = conf
-}
-
-func (cmd *command) setSession(loc string) {
-	if loc == "" {
-		var err error
-		loc, err = conf.GetDefaultSessionLocation()
-		if err != nil {
-			fmt.Fprint(os.Stderr, errors.Wrap(err, "failed to find session location"))
-			os.Exit(-1)
-		}
-		os.MkdirAll(filepath.Dir(loc), 0755)
-		f, err := os.OpenFile(loc, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
-		if err != nil && !os.IsExist(err) {
-			fmt.Fprint(os.Stderr, errors.Wrapf(err, "failed to create session file %v", loc))
-		}
-		f.Write([]byte("{}"))
-		f.Close()
-	}
-	cmd.session = conf.NewSession(loc)
-}
-
-func setVerbose(verbose bool) {
-	if verbose {
-		logrus.SetFormatter(new(logrus.TextFormatter))
-		logrus.SetLevel(logrus.DebugLevel)
-	}
-}
-
-func (cmd *command) setJSON(json bool) {
-	cmd.jsonOutput = json
-	if json {
-		logrus.SetFormatter(new(logrus.JSONFormatter))
-	}
-}
-
 func newCommand(title, synopsis, help string, opts interface{}) (*command, error) {
 	cmd := &command{
 		help:     help,
@@ -157,4 +99,66 @@ func (c *command) Run(args []string) int {
 	}
 
 	return 0
+}
+
+//setConfig sets the cmd.config field according to the config file location
+func (c *command) setConfig(loc string) {
+	if loc == "" {
+		var err error
+		loc, err = conf.GetDefaultConfigLocation()
+		if err != nil {
+			fmt.Fprint(os.Stderr, errors.Wrap(err, "failed to find config location"))
+			os.Exit(-1)
+		}
+		os.MkdirAll(filepath.Dir(loc), 0755)
+		f, err := os.OpenFile(loc, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+		if err != nil && !os.IsExist(err) {
+			fmt.Fprint(os.Stderr, errors.Wrapf(err, "failed to create config file %v", loc))
+			os.Exit(-1)
+		}
+		f.Write([]byte("{}"))
+		f.Close()
+	}
+	conf, err := conf.Read(loc)
+	if err != nil {
+		fmt.Fprint(os.Stderr, errors.Wrap(err, "failed to read config file"))
+		os.Exit(-1)
+	}
+	c.config = conf
+}
+
+//setSession sets the cmd.session field according to the session file location
+func (c *command) setSession(loc string) {
+	if loc == "" {
+		var err error
+		loc, err = conf.GetDefaultSessionLocation()
+		if err != nil {
+			fmt.Fprint(os.Stderr, errors.Wrap(err, "failed to find session location"))
+			os.Exit(-1)
+		}
+		os.MkdirAll(filepath.Dir(loc), 0755)
+		f, err := os.OpenFile(loc, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+		if err != nil && !os.IsExist(err) {
+			fmt.Fprint(os.Stderr, errors.Wrapf(err, "failed to create session file %v", loc))
+		}
+		f.Write([]byte("{}"))
+		f.Close()
+	}
+	c.session = conf.NewSession(loc)
+}
+
+//setVerbose sets verbose output formatting
+func setVerbose(verbose bool) {
+	if verbose {
+		logrus.SetFormatter(new(logrus.TextFormatter))
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+}
+
+//setJSON sets json output formatting
+func (c *command) setJSON(json bool) {
+	c.jsonOutput = json
+	if json {
+		logrus.SetFormatter(new(logrus.JSONFormatter))
+	}
 }

--- a/command/command.go
+++ b/command/command.go
@@ -2,19 +2,58 @@ package command
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
+	"github.com/nerdalize/nerd/nerd/conf"
 )
 
 var errShowHelp = errors.New("show error")
 
-func (cmd *command) setConfigLocation(loc string) {
-	cmd.configLocation = loc
+func (cmd *command) setConfig(loc string) {
+	if loc == "" {
+		loc, err := conf.GetDefaultConfigLocation()
+		if err != nil {
+			fmt.Fprint(os.Stderr, errors.Wrap(err, "failed to find config location"))
+			os.Exit(-1)
+		}
+		os.MkdirAll(filepath.Dir(loc), 0755)
+		f, err := os.OpenFile(loc, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+		if err != nil && !os.IsExist(err) {
+			fmt.Fprint(os.Stderr, errors.Wrapf(err, "failed to create config file %v", loc))
+			os.Exit(-1)
+		}
+		f.Close()
+	}
+	conf, err := conf.Read(loc)
+	if err != nil {
+		fmt.Fprint(os.Stderr, errors.Wrap(err, "failed to read config file"))
+		os.Exit(-1)
+	}
+	cmd.config = conf
+}
+
+func (cmd *command) setSession(loc string) {
+	if loc == "" {
+		loc, err := conf.GetDefaultSessionLocation()
+		if err != nil {
+			fmt.Fprint(os.Stderr, errors.Wrap(err, "failed to find session location"))
+			os.Exit(-1)
+		}
+		os.MkdirAll(filepath.Dir(loc), 0755)
+		f, err := os.OpenFile(loc, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+		if err != nil && !os.IsExist(err) {
+			fmt.Fprint(os.Stderr, errors.Wrapf(err, "failed to create session file %v", loc))
+		}
+		f.Close()
+	}
+	cmd.session = conf.NewSession(loc)
 }
 
 func setVerbose(verbose bool) {
@@ -48,7 +87,8 @@ func newCommand(title, synopsis, help string, opts interface{}) (*command, error
 		}
 	}
 	confOpts := &ConfOpts{
-		ConfigFile: cmd.setConfigLocation,
+		ConfigFile:  cmd.setConfig,
+		SessionFile: cmd.setSession,
 		OutputOpts: OutputOpts{
 			VerboseOutput: setVerbose,
 			JSONOutput:    cmd.setJSON,
@@ -63,16 +103,14 @@ func newCommand(title, synopsis, help string, opts interface{}) (*command, error
 
 //command is an abstract implementation for embedding in concrete commands and allows basic command functionality to be reused.
 type command struct {
-	help           string        //extended help message, show when --help a command
-	synopsis       string        //short help message, shown on the command overview
-	parser         *flags.Parser //option parser that will be used when parsing args
-	ui             cli.Ui
-	configLocation string
-	jsonOutput     bool
-	// conf     conf.ConfInterface
-	// confOpts *ConfOpts
-	// renderer Renderer
-	runFunc func(args []string) error
+	help       string        //extended help message, show when --help a command
+	synopsis   string        //short help message, shown on the command overview
+	parser     *flags.Parser //option parser that will be used when parsing args
+	ui         cli.Ui
+	config     *conf.Config
+	jsonOutput bool
+	session    *conf.Session
+	runFunc    func(args []string) error
 }
 
 //Will write help text for when a user uses --help, it automatically renders all option groups of the flags.Parser (augmented with default values). It will show an extended help message if it is not empty, else it shows the synopsis.

--- a/command/command.go
+++ b/command/command.go
@@ -4,20 +4,75 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
 )
 
 var errShowHelp = errors.New("show error")
 
+func (cmd *command) setConfigLocation(loc string) {
+	cmd.configLocation = loc
+}
+
+func setVerbose(verbose bool) {
+	if verbose {
+		logrus.SetFormatter(new(logrus.TextFormatter))
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+}
+
+func (cmd *command) setJSON(json bool) {
+	cmd.jsonOutput = json
+	if json {
+		logrus.SetFormatter(new(logrus.JSONFormatter))
+	}
+}
+
+func newCommand(title, synopsis, help string, opts interface{}) (*command, error) {
+	cmd := &command{
+		help:     help,
+		synopsis: synopsis,
+		parser:   flags.NewNamedParser(title, flags.None),
+		ui: &cli.BasicUi{
+			Reader: os.Stdin,
+			Writer: os.Stderr,
+		},
+	}
+	if opts != nil {
+		_, err := cmd.parser.AddGroup("options", "options", opts)
+		if err != nil {
+			return nil, err
+		}
+	}
+	confOpts := &ConfOpts{
+		ConfigFile: cmd.setConfigLocation,
+		OutputOpts: OutputOpts{
+			VerboseOutput: setVerbose,
+			JSONOutput:    cmd.setJSON,
+		},
+	}
+	_, err := cmd.parser.AddGroup("output options", "output options", confOpts)
+	if err != nil {
+		return nil, err
+	}
+	return cmd, nil
+}
+
 //command is an abstract implementation for embedding in concrete commands and allows basic command functionality to be reused.
 type command struct {
-	help     string        //extended help message, show when --help a command
-	synopsis string        //short help message, shown on the command overview
-	parser   *flags.Parser //option parser that will be used when parsing args
-	ui       cli.Ui
-	runFunc  func(args []string) error
+	help           string        //extended help message, show when --help a command
+	synopsis       string        //short help message, shown on the command overview
+	parser         *flags.Parser //option parser that will be used when parsing args
+	ui             cli.Ui
+	configLocation string
+	jsonOutput     bool
+	// conf     conf.ConfInterface
+	// confOpts *ConfOpts
+	// renderer Renderer
+	runFunc func(args []string) error
 }
 
 //Will write help text for when a user uses --help, it automatically renders all option groups of the flags.Parser (augmented with default values). It will show an extended help message if it is not empty, else it shows the synopsis.

--- a/command/command.go
+++ b/command/command.go
@@ -18,7 +18,8 @@ var errShowHelp = errors.New("show error")
 
 func (cmd *command) setConfig(loc string) {
 	if loc == "" {
-		loc, err := conf.GetDefaultConfigLocation()
+		var err error
+		loc, err = conf.GetDefaultConfigLocation()
 		if err != nil {
 			fmt.Fprint(os.Stderr, errors.Wrap(err, "failed to find config location"))
 			os.Exit(-1)
@@ -29,6 +30,7 @@ func (cmd *command) setConfig(loc string) {
 			fmt.Fprint(os.Stderr, errors.Wrapf(err, "failed to create config file %v", loc))
 			os.Exit(-1)
 		}
+		f.Write([]byte("{}"))
 		f.Close()
 	}
 	conf, err := conf.Read(loc)
@@ -41,7 +43,8 @@ func (cmd *command) setConfig(loc string) {
 
 func (cmd *command) setSession(loc string) {
 	if loc == "" {
-		loc, err := conf.GetDefaultSessionLocation()
+		var err error
+		loc, err = conf.GetDefaultSessionLocation()
 		if err != nil {
 			fmt.Fprint(os.Stderr, errors.Wrap(err, "failed to find session location"))
 			os.Exit(-1)
@@ -51,6 +54,7 @@ func (cmd *command) setSession(loc string) {
 		if err != nil && !os.IsExist(err) {
 			fmt.Fprint(os.Stderr, errors.Wrapf(err, "failed to create session file %v", loc))
 		}
+		f.Write([]byte("{}"))
 		f.Close()
 	}
 	cmd.session = conf.NewSession(loc)

--- a/command/dataset.go
+++ b/command/dataset.go
@@ -1,10 +1,8 @@
 package command
 
 import (
-	"os"
-
-	flags "github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
+	"github.com/pkg/errors"
 )
 
 //Dataset command
@@ -14,19 +12,15 @@ type Dataset struct {
 
 //DatasetFactory returns a factory method for the join command
 func DatasetFactory() (cli.Command, error) {
-	cmd := &Dataset{
-		command: &command{
-			help:     `upload and download datasets for tasks to use`,
-			synopsis: "upload and download datasets for tasks to use",
-			parser:   flags.NewNamedParser("nerd dataset <subcommand>", flags.Default),
-			ui: &cli.BasicUi{
-				Reader: os.Stdin,
-				Writer: os.Stderr,
-			},
-		},
+	comm, err := newCommand("nerd dataset <subcommand>", "upload and download datasets for tasks to use", "", nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create command")
 	}
-
+	cmd := &Dataset{
+		command: comm,
+	}
 	cmd.runFunc = cmd.DoRun
+
 	return cmd, nil
 }
 

--- a/command/dataset_download.go
+++ b/command/dataset_download.go
@@ -7,11 +7,9 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
 	"github.com/nerdalize/nerd/nerd/aws"
 	v1payload "github.com/nerdalize/nerd/nerd/client/batch/v1/payload"
-	"github.com/nerdalize/nerd/nerd/conf"
 	v1datatransfer "github.com/nerdalize/nerd/nerd/service/datatransfer/v1"
 	"github.com/pkg/errors"
 )
@@ -27,41 +25,21 @@ const (
 	TagPrefix = "tag-"
 )
 
-//DownloadOpts describes command options
-type DownloadOpts struct {
-	NerdOpts
-	AlwaysOverwrite bool `long:"always-overwrite" default-mask:"false" description:"always overwrite files when they already exist"`
-}
-
 //Download command
 type Download struct {
 	*command
-
-	opts   *DownloadOpts
-	parser *flags.Parser
 }
 
 //DatasetDownloadFactory returns a factory method for the join command
 func DatasetDownloadFactory() (cli.Command, error) {
-	cmd := &Download{
-		command: &command{
-			help:     "",
-			synopsis: "download data from the cloud to a local directory",
-			parser:   flags.NewNamedParser("nerd dataset download <dataset> <output-dir>", flags.Default),
-			ui: &cli.BasicUi{
-				Reader: os.Stdin,
-				Writer: os.Stderr,
-			},
-		},
-
-		opts: &DownloadOpts{},
-	}
-
-	cmd.runFunc = cmd.DoRun
-	_, err := cmd.command.parser.AddGroup("options", "options", cmd.opts)
+	comm, err := newCommand("nerd dataset download <dataset> <output-dir>", "download data from the cloud to a local directory", "", nil)
 	if err != nil {
-		panic(err)
+		return nil, errors.Wrap(err, "failed to create command")
 	}
+	cmd := &Download{
+		command: comm,
+	}
+	cmd.runFunc = cmd.DoRun
 
 	return cmd, nil
 }
@@ -70,11 +48,6 @@ func DatasetDownloadFactory() (cli.Command, error) {
 func (cmd *Download) DoRun(args []string) (err error) {
 	if len(args) < 2 {
 		return fmt.Errorf("not enough arguments, see --help")
-	}
-
-	config, err := conf.Read()
-	if err != nil {
-		HandleError(err)
 	}
 
 	downloadObject := args[0]
@@ -96,13 +69,17 @@ func (cmd *Download) DoRun(args []string) (err error) {
 	}
 
 	// Clients
-	batchclient, err := NewClient(cmd.ui)
+	batchclient, err := NewClient(cmd.ui, cmd.config, cmd.session)
+	if err != nil {
+		HandleError(err)
+	}
+	ss, err := cmd.session.Read()
 	if err != nil {
 		HandleError(err)
 	}
 	dataOps, err := aws.NewDataClient(
-		aws.NewNerdalizeCredentials(batchclient, config.CurrentProject.Name),
-		config.CurrentProject.AWSRegion,
+		aws.NewNerdalizeCredentials(batchclient, ss.Project.Name),
+		ss.Project.AWSRegion,
 	)
 	if err != nil {
 		HandleError(errors.Wrap(err, "could not create aws dataops client"))
@@ -114,7 +91,7 @@ func (cmd *Download) DoRun(args []string) (err error) {
 		datasetIDs = append(datasetIDs, downloadObject)
 	} else {
 		var datasets *v1payload.ListDatasetsOutput
-		datasets, err = batchclient.ListDatasets(config.CurrentProject.Name, downloadObject)
+		datasets, err = batchclient.ListDatasets(ss.Project.Name, downloadObject)
 		if err != nil {
 			HandleError(err)
 		}
@@ -130,7 +107,7 @@ func (cmd *Download) DoRun(args []string) (err error) {
 			BatchClient: batchclient,
 			DataOps:     dataOps,
 			LocalDir:    outputDir,
-			ProjectID:   config.CurrentProject.Name,
+			ProjectID:   ss.Project.Name,
 			DatasetID:   datasetID,
 			Concurrency: 64,
 		}
@@ -138,7 +115,7 @@ func (cmd *Download) DoRun(args []string) (err error) {
 			progressCh := make(chan int64)
 			progressBarDoneCh := make(chan struct{})
 			var size int64
-			size, err = v1datatransfer.GetRemoteDatasetSize(context.Background(), batchclient, dataOps, config.CurrentProject.Name, datasetID)
+			size, err = v1datatransfer.GetRemoteDatasetSize(context.Background(), batchclient, dataOps, ss.Project.Name, datasetID)
 			if err != nil {
 				HandleError(err)
 			}

--- a/command/dataset_download.go
+++ b/command/dataset_download.go
@@ -134,7 +134,7 @@ func (cmd *Download) DoRun(args []string) (err error) {
 			DatasetID:   datasetID,
 			Concurrency: 64,
 		}
-		if !cmd.opts.JSONOutput { // show progress bar
+		if !cmd.jsonOutput { // show progress bar
 			progressCh := make(chan int64)
 			progressBarDoneCh := make(chan struct{})
 			var size int64

--- a/command/dataset_upload.go
+++ b/command/dataset_upload.go
@@ -103,7 +103,7 @@ func (cmd *Upload) DoRun(args []string) (err error) {
 		Tag:         cmd.opts.Tag,
 		Concurrency: 64,
 	}
-	if !cmd.opts.JSONOutput { // show progress bar
+	if !cmd.jsonOutput { // show progress bar
 		progressCh := make(chan int64)
 		progressBarDoneCh := make(chan struct{})
 		size, err := v1datatransfer.GetLocalDatasetSize(context.Background(), dataPath)

--- a/command/login.go
+++ b/command/login.go
@@ -76,6 +76,7 @@ func (cmd *Login) DoRun(args []string) error {
 	if err != nil {
 		HandleError(errors.Wrap(err, "failed to write oauth tokens to config"))
 	}
+	cmd.ui.Info("Successful login. You can now select a project using 'nerd project set'.")
 	return nil
 }
 

--- a/command/login.go
+++ b/command/login.go
@@ -5,11 +5,9 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
-	"os"
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
 	v1auth "github.com/nerdalize/nerd/nerd/client/auth/v1"
 	"github.com/nerdalize/nerd/nerd/conf"
@@ -21,53 +19,30 @@ const (
 	authorizeEndpoint = "o/authorize"
 )
 
-//LoginOpts describes command options
-type LoginOpts struct {
-	NerdOpts
-}
-
 //Login command
 type Login struct {
 	*command
-
-	opts   *LoginOpts
-	parser *flags.Parser
 }
 
 //LoginFactory returns a factory method for the join command
 func LoginFactory() (cli.Command, error) {
-	cmd := &Login{
-		command: &command{
-			help:     "",
-			synopsis: "start a new authorized session",
-			parser:   flags.NewNamedParser("nerd login", flags.Default),
-			ui: &cli.BasicUi{
-				Reader: os.Stdin,
-				Writer: os.Stderr,
-			},
-		},
-
-		opts: &LoginOpts{},
-	}
-
-	cmd.runFunc = cmd.DoRun
-	_, err := cmd.command.parser.AddGroup("options", "options", cmd.opts)
+	comm, err := newCommand("nerd login", "start a new authorized session", "", nil)
 	if err != nil {
-		panic(err)
+		return nil, errors.Wrap(err, "failed to create command")
 	}
+	cmd := &Login{
+		command: comm,
+	}
+	cmd.runFunc = cmd.DoRun
 
 	return cmd, nil
 }
 
 //DoRun is called by run and allows an error to be returned
 func (cmd *Login) DoRun(args []string) error {
-	c, err := conf.Read()
+	authbase, err := url.Parse(cmd.config.Auth.APIEndpoint)
 	if err != nil {
-		HandleError(errors.Wrap(err, "failed to read config"))
-	}
-	authbase, err := url.Parse(c.Auth.APIEndpoint)
-	if err != nil {
-		HandleError(errors.Wrapf(err, "auth endpoint '%v' is not a valid URL", c.Auth.APIEndpoint))
+		HandleError(errors.Wrapf(err, "auth endpoint '%v' is not a valid URL", cmd.config.Auth.APIEndpoint))
 	}
 	authOpsClient := v1auth.NewOpsClient(v1auth.OpsClientConfig{
 		Base:   authbase,
@@ -76,12 +51,12 @@ func (cmd *Login) DoRun(args []string) error {
 	randomState := randomString(32)
 	doneCh := make(chan response)
 	svr := &http.Server{
-		Addr: c.Auth.OAuthLocalServer,
+		Addr: cmd.config.Auth.OAuthLocalServer,
 	}
 	defer svr.Close()
-	go spawnServer(svr, c.Auth, randomState, doneCh)
+	go spawnServer(svr, cmd.config.Auth, randomState, doneCh)
 
-	err = open.Run(fmt.Sprintf("http://%s/oauth?state=%s", c.Auth.OAuthLocalServer, randomState))
+	err = open.Run(fmt.Sprintf("http://%s/oauth?state=%s", cmd.config.Auth.OAuthLocalServer, randomState))
 	if err != nil {
 		HandleError(errors.Wrap(err, "Failed to open browser window. Please see github.com/nerdalize/nerd for alternative ways of authenticating."))
 	}
@@ -91,13 +66,13 @@ func (cmd *Login) DoRun(args []string) error {
 		HandleError(errors.Wrap(oauthResponse.err, "failed to do oauth login"))
 	}
 
-	out, err := authOpsClient.GetOAuthCredentials(oauthResponse.code, c.Auth.ClientID, fmt.Sprintf("http://%s/oauth/callback", c.Auth.OAuthLocalServer))
+	out, err := authOpsClient.GetOAuthCredentials(oauthResponse.code, cmd.config.Auth.ClientID, fmt.Sprintf("http://%s/oauth/callback", cmd.config.Auth.OAuthLocalServer))
 	if err != nil {
 		HandleError(errors.Wrap(err, "failed to get oauth credentials"))
 	}
 
 	expiration := time.Unix(time.Now().Unix()+int64(out.ExpiresIn), 0)
-	err = conf.WriteOAuth(out.AccessToken, out.RefreshToken, expiration, out.Scope, out.TokenType)
+	err = cmd.session.WriteOAuth(out.AccessToken, out.RefreshToken, expiration, out.Scope, out.TokenType)
 	if err != nil {
 		HandleError(errors.Wrap(err, "failed to write oauth tokens to config"))
 	}

--- a/command/opts.go
+++ b/command/opts.go
@@ -2,8 +2,8 @@ package command
 
 //OutputOpts are options that are related to CLI output.
 type OutputOpts struct {
-	VerboseOutput bool `short:"v" long:"verbose" default-mask:"false" description:"show verbose output"`
-	JSONOutput    bool `long:"json-format" default-mask:"false" description:"show output in json format"`
+	VerboseOutput func(bool) `short:"v" long:"verbose" default:"false" optional:"true" optional-value:"true" description:"show verbose output"`
+	JSONOutput    func(bool) `long:"json-format" default:"false" optional:"true" optional-value:"true" description:"show output in json format"`
 }
 
 //NerdOpts are the options that are applicable to all nerd commands.
@@ -13,6 +13,6 @@ type NerdOpts struct {
 
 //ConfOpts are the options related to config file and the way output is handled.
 type ConfOpts struct {
-	ConfigFile string `long:"config" default:"" default-mask:"" env:"CONFIG" description:"location of config file"`
+	ConfigFile func(string) `long:"config" default:"" default-mask:"" env:"CONFIG" description:"location of config file"`
 	OutputOpts
 }

--- a/command/opts.go
+++ b/command/opts.go
@@ -6,13 +6,9 @@ type OutputOpts struct {
 	JSONOutput    func(bool) `long:"json-format" default:"false" optional:"true" optional-value:"true" description:"show output in json format"`
 }
 
-//NerdOpts are the options that are applicable to all nerd commands.
-type NerdOpts struct {
-	ConfOpts
-}
-
 //ConfOpts are the options related to config file and the way output is handled.
 type ConfOpts struct {
-	ConfigFile func(string) `long:"config" default:"" default-mask:"" env:"CONFIG" description:"location of config file"`
+	ConfigFile  func(string) `long:"config-file" default:"" default-mask:"" env:"NERD_CONFIG_FILE" description:"location of config file"`
+	SessionFile func(string) `long:"session-file" default:"" default-mask:"" env:"NERD_SESSION_FILE" description:"location of session file"`
 	OutputOpts
 }

--- a/command/project.go
+++ b/command/project.go
@@ -1,10 +1,8 @@
 package command
 
 import (
-	"os"
-
-	flags "github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
+	"github.com/pkg/errors"
 )
 
 //Project command
@@ -14,19 +12,15 @@ type Project struct {
 
 //ProjectFactory returns a factory method for the join command
 func ProjectFactory() (cli.Command, error) {
-	cmd := &Queue{
-		command: &command{
-			help:     "",
-			synopsis: "set and list projects",
-			parser:   flags.NewNamedParser("nerd project <subcommand>", flags.Default),
-			ui: &cli.BasicUi{
-				Reader: os.Stdin,
-				Writer: os.Stderr,
-			},
-		},
+	comm, err := newCommand("nerd project <subcommand>", "set and list projects", "", nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create command")
 	}
-
+	cmd := &Project{
+		command: comm,
+	}
 	cmd.runFunc = cmd.DoRun
+
 	return cmd, nil
 }
 

--- a/command/project_list.go
+++ b/command/project_list.go
@@ -3,63 +3,38 @@ package command
 import (
 	"fmt"
 	"net/url"
-	"os"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
 	v1auth "github.com/nerdalize/nerd/nerd/client/auth/v1"
-	"github.com/nerdalize/nerd/nerd/conf"
 	"github.com/nerdalize/nerd/nerd/oauth"
 	"github.com/pkg/errors"
 )
 
-//ProjectListOps describes command options
-type ProjectListOps struct {
-	NerdOpts
-}
-
 //ProjectList command
 type ProjectList struct {
 	*command
-	opts   *ProjectListOps
-	parser *flags.Parser
 }
 
 //ProjectListFactory returns a factory method for the join command
 func ProjectListFactory() (cli.Command, error) {
-	cmd := &ProjectList{
-		command: &command{
-			help:     "",
-			synopsis: "list all your projects",
-			parser:   flags.NewNamedParser("nerd project list", flags.Default),
-			ui: &cli.BasicUi{
-				Reader: os.Stdin,
-				Writer: os.Stderr,
-			},
-		},
-
-		opts: &ProjectListOps{},
-	}
-
-	cmd.runFunc = cmd.DoRun
-	_, err := cmd.command.parser.AddGroup("options", "options", cmd.opts)
+	comm, err := newCommand("nerd project list", "list all your projects", "", nil)
 	if err != nil {
-		panic(err)
+		return nil, errors.Wrap(err, "failed to create command")
 	}
+	cmd := &ProjectList{
+		command: comm,
+	}
+	cmd.runFunc = cmd.DoRun
 
 	return cmd, nil
 }
 
 //DoRun is called by run and allows an error to be returned
 func (cmd *ProjectList) DoRun(args []string) (err error) {
-	config, err := conf.Read()
+	authbase, err := url.Parse(cmd.config.Auth.APIEndpoint)
 	if err != nil {
-		HandleError(err)
-	}
-	authbase, err := url.Parse(config.Auth.APIEndpoint)
-	if err != nil {
-		HandleError(errors.Wrapf(err, "auth endpoint '%v' is not a valid URL", config.Auth.APIEndpoint))
+		HandleError(errors.Wrapf(err, "auth endpoint '%v' is not a valid URL", cmd.config.Auth.APIEndpoint))
 	}
 	authOpsClient := v1auth.NewOpsClient(v1auth.OpsClientConfig{
 		Base:   authbase,
@@ -68,7 +43,7 @@ func (cmd *ProjectList) DoRun(args []string) (err error) {
 	client := v1auth.NewClient(v1auth.ClientConfig{
 		Base:               authbase,
 		Logger:             logrus.StandardLogger(),
-		OAuthTokenProvider: oauth.NewConfigProvider(authOpsClient),
+		OAuthTokenProvider: oauth.NewConfigProvider(authOpsClient, cmd.config.Auth.ClientID, cmd.session),
 	})
 
 	projects, err := client.ListProjects()

--- a/command/project_set.go
+++ b/command/project_set.go
@@ -2,46 +2,27 @@ package command
 
 import (
 	"fmt"
-	"os"
 
-	"github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
 	"github.com/nerdalize/nerd/nerd/conf"
+	"github.com/pkg/errors"
 )
-
-//ProjectSetOps describes command options
-type ProjectSetOps struct {
-	NerdOpts
-}
 
 //ProjectSet command
 type ProjectSet struct {
 	*command
-	opts   *ProjectSetOps
-	parser *flags.Parser
 }
 
 //ProjectSetFactory returns a factory method for the join command
 func ProjectSetFactory() (cli.Command, error) {
-	cmd := &ProjectSet{
-		command: &command{
-			help:     "",
-			synopsis: "set current working project",
-			parser:   flags.NewNamedParser("nerd project set <project-name>", flags.Default),
-			ui: &cli.BasicUi{
-				Reader: os.Stdin,
-				Writer: os.Stderr,
-			},
-		},
-
-		opts: &ProjectSetOps{},
-	}
-
-	cmd.runFunc = cmd.DoRun
-	_, err := cmd.command.parser.AddGroup("options", "options", cmd.opts)
+	comm, err := newCommand("nerd project set", "set current working project", "", nil)
 	if err != nil {
-		panic(err)
+		return nil, errors.Wrap(err, "failed to create command")
 	}
+	cmd := &ProjectSet{
+		command: comm,
+	}
+	cmd.runFunc = cmd.DoRun
 
 	return cmd, nil
 }
@@ -52,7 +33,7 @@ func (cmd *ProjectSet) DoRun(args []string) (err error) {
 		return fmt.Errorf("not enough arguments, see --help")
 	}
 
-	err = conf.WriteProject(args[0])
+	err = cmd.session.WriteProject(args[0], conf.DefaultAWSRegion)
 	if err != nil {
 		HandleError(err)
 	}

--- a/command/queue.go
+++ b/command/queue.go
@@ -1,10 +1,8 @@
 package command
 
 import (
-	"os"
-
-	flags "github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
+	"github.com/pkg/errors"
 )
 
 //Queue command
@@ -14,19 +12,15 @@ type Queue struct {
 
 //QueueFactory returns a factory method for the join command
 func QueueFactory() (cli.Command, error) {
-	cmd := &Queue{
-		command: &command{
-			help:     `setup queues that transport tasks to workers`,
-			synopsis: "setup queues that transport tasks to workers",
-			parser:   flags.NewNamedParser("nerd queue", flags.Default),
-			ui: &cli.BasicUi{
-				Reader: os.Stdin,
-				Writer: os.Stderr,
-			},
-		},
+	comm, err := newCommand("nerd queue <subcommand>", "setup queues that transport tasks to workers", "", nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create command")
 	}
-
+	cmd := &Queue{
+		command: comm,
+	}
 	cmd.runFunc = cmd.DoRun
+
 	return cmd, nil
 }
 

--- a/command/task.go
+++ b/command/task.go
@@ -1,10 +1,8 @@
 package command
 
 import (
-	"os"
-
-	flags "github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
+	"github.com/pkg/errors"
 )
 
 //Task command
@@ -14,19 +12,15 @@ type Task struct {
 
 //TaskFactory returns a factory method for the join command
 func TaskFactory() (cli.Command, error) {
-	cmd := &Task{
-		command: &command{
-			help:     `manage the lifecycle of compute tasks`,
-			synopsis: "manage the lifecycle of compute tasks",
-			parser:   flags.NewNamedParser("nerd task", flags.Default),
-			ui: &cli.BasicUi{
-				Reader: os.Stdin,
-				Writer: os.Stderr,
-			},
-		},
+	comm, err := newCommand("nerd task <subcommand>", "manage the lifecycle of compute tasks", "", nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create command")
 	}
-
+	cmd := &Task{
+		command: comm,
+	}
 	cmd.runFunc = cmd.DoRun
+
 	return cmd, nil
 }
 

--- a/command/task_failure.go
+++ b/command/task_failure.go
@@ -2,49 +2,28 @@ package command
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
-	"github.com/nerdalize/nerd/nerd/conf"
 	"github.com/pkg/errors"
 )
-
-//TaskFailureOpts describes command options
-type TaskFailureOpts struct {
-	NerdOpts
-}
 
 //TaskFailure command
 type TaskFailure struct {
 	*command
-	opts   *TaskFailureOpts
-	parser *flags.Parser
 }
 
 //TaskFailureFactory returns a factory method for the join command
 func TaskFailureFactory() (cli.Command, error) {
-	cmd := &TaskFailure{
-		command: &command{
-			help:     "",
-			synopsis: "mark a task run as being failed",
-			parser:   flags.NewNamedParser("nerd task failure <queue-id> <task-id> <run-token> <error-code> <err-message>", flags.Default),
-			ui: &cli.BasicUi{
-				Reader: os.Stdin,
-				Writer: os.Stderr,
-			},
-		},
-
-		opts: &TaskFailureOpts{},
-	}
-
-	cmd.runFunc = cmd.DoRun
-	_, err := cmd.command.parser.AddGroup("options", "options", cmd.opts)
+	comm, err := newCommand("nerd task failure <queue-id> <task-id> <run-token> <error-code> <err-message>", "mark a task run as being failed", "", nil)
 	if err != nil {
-		panic(err)
+		return nil, errors.Wrap(err, "failed to create command")
 	}
+	cmd := &TaskFailure{
+		command: comm,
+	}
+	cmd.runFunc = cmd.DoRun
 
 	return cmd, nil
 }
@@ -55,12 +34,7 @@ func (cmd *TaskFailure) DoRun(args []string) (err error) {
 		return fmt.Errorf("not enough arguments, see --help")
 	}
 
-	config, err := conf.Read()
-	if err != nil {
-		HandleError(err)
-	}
-
-	bclient, err := NewClient(cmd.ui)
+	bclient, err := NewClient(cmd.ui, cmd.config, cmd.session)
 	if err != nil {
 		HandleError(err)
 	}
@@ -70,7 +44,11 @@ func (cmd *TaskFailure) DoRun(args []string) (err error) {
 		HandleError(errors.Wrap(err, "invalid task ID, must be a number"))
 	}
 
-	out, err := bclient.SendRunFailure(config.CurrentProject.Name, args[0], taskID, args[2], args[3], args[4])
+	ss, err := cmd.session.Read()
+	if err != nil {
+		HandleError(err)
+	}
+	out, err := bclient.SendRunFailure(ss.Project.Name, args[0], taskID, args[2], args[3], args[4])
 	if err != nil {
 		HandleError(err)
 	}

--- a/command/task_heartbeat.go
+++ b/command/task_heartbeat.go
@@ -2,49 +2,28 @@ package command
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
-	"github.com/nerdalize/nerd/nerd/conf"
 	"github.com/pkg/errors"
 )
-
-//TaskHeartbeatOpts describes command options
-type TaskHeartbeatOpts struct {
-	NerdOpts
-}
 
 //TaskHeartbeat command
 type TaskHeartbeat struct {
 	*command
-	opts   *TaskHeartbeatOpts
-	parser *flags.Parser
 }
 
 //TaskHeartbeatFactory returns a factory method for the join command
 func TaskHeartbeatFactory() (cli.Command, error) {
-	cmd := &TaskHeartbeat{
-		command: &command{
-			help:     "",
-			synopsis: "indicate that a task run is still in progress",
-			parser:   flags.NewNamedParser("nerd task heartbeat <queue-id> <task-id> <run-token>", flags.Default),
-			ui: &cli.BasicUi{
-				Reader: os.Stdin,
-				Writer: os.Stderr,
-			},
-		},
-
-		opts: &TaskHeartbeatOpts{},
-	}
-
-	cmd.runFunc = cmd.DoRun
-	_, err := cmd.command.parser.AddGroup("options", "options", cmd.opts)
+	comm, err := newCommand("nerd task heartbeat <queue-id> <task-id> <run-token>", "indicate that a task run is still in progress", "", nil)
 	if err != nil {
-		panic(err)
+		return nil, errors.Wrap(err, "failed to create command")
 	}
+	cmd := &TaskHeartbeat{
+		command: comm,
+	}
+	cmd.runFunc = cmd.DoRun
 
 	return cmd, nil
 }
@@ -55,12 +34,7 @@ func (cmd *TaskHeartbeat) DoRun(args []string) (err error) {
 		return fmt.Errorf("not enough arguments, see --help")
 	}
 
-	config, err := conf.Read()
-	if err != nil {
-		HandleError(err)
-	}
-
-	bclient, err := NewClient(cmd.ui)
+	bclient, err := NewClient(cmd.ui, cmd.config, cmd.session)
 	if err != nil {
 		HandleError(err)
 	}
@@ -70,7 +44,11 @@ func (cmd *TaskHeartbeat) DoRun(args []string) (err error) {
 		HandleError(errors.Wrap(err, "invalid task ID, must be a number"))
 	}
 
-	out, err := bclient.SendRunHeartbeat(config.CurrentProject.Name, args[0], taskID, args[2])
+	ss, err := cmd.session.Read()
+	if err != nil {
+		HandleError(err)
+	}
+	out, err := bclient.SendRunHeartbeat(ss.Project.Name, args[0], taskID, args[2])
 	if err != nil {
 		HandleError(err)
 	}

--- a/command/task_receive.go
+++ b/command/task_receive.go
@@ -2,49 +2,29 @@ package command
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
 	nerdaws "github.com/nerdalize/nerd/nerd/aws"
-	"github.com/nerdalize/nerd/nerd/conf"
+	"github.com/pkg/errors"
 )
-
-//TaskReceiveOpts describes command options
-type TaskReceiveOpts struct {
-	NerdOpts
-}
 
 //TaskReceive command
 type TaskReceive struct {
 	*command
-	opts   *TaskReceiveOpts
-	parser *flags.Parser
 }
 
 //TaskReceiveFactory returns a factory method for the join command
 func TaskReceiveFactory() (cli.Command, error) {
-	cmd := &TaskReceive{
-		command: &command{
-			help:     "",
-			synopsis: "wait for a new task run to be available on a queue",
-			parser:   flags.NewNamedParser("nerd task receive <queue-id>", flags.Default),
-			ui: &cli.BasicUi{
-				Reader: os.Stdin,
-				Writer: os.Stderr,
-			},
-		},
-
-		opts: &TaskReceiveOpts{},
-	}
-
-	cmd.runFunc = cmd.DoRun
-	_, err := cmd.command.parser.AddGroup("options", "options", cmd.opts)
+	comm, err := newCommand("nerd task receive <queue-id>", "wait for a new task run to be available on a queue", "", nil)
 	if err != nil {
-		panic(err)
+		return nil, errors.Wrap(err, "failed to create command")
 	}
+	cmd := &TaskReceive{
+		command: comm,
+	}
+	cmd.runFunc = cmd.DoRun
 
 	return cmd, nil
 }
@@ -55,23 +35,22 @@ func (cmd *TaskReceive) DoRun(args []string) (err error) {
 		return fmt.Errorf("not enough arguments, see --help")
 	}
 
-	config, err := conf.Read()
+	bclient, err := NewClient(cmd.ui, cmd.config, cmd.session)
 	if err != nil {
 		HandleError(err)
 	}
 
-	bclient, err := NewClient(cmd.ui)
+	ss, err := cmd.session.Read()
+	if err != nil {
+		HandleError(err)
+	}
+	creds := nerdaws.NewNerdalizeCredentials(bclient, ss.Project.Name)
+	qops, err := nerdaws.NewQueueClient(creds, ss.Project.AWSRegion)
 	if err != nil {
 		HandleError(err)
 	}
 
-	creds := nerdaws.NewNerdalizeCredentials(bclient, config.CurrentProject.Name)
-	qops, err := nerdaws.NewQueueClient(creds, config.CurrentProject.AWSRegion) //@TODO get region from credentials provider
-	if err != nil {
-		HandleError(err)
-	}
-
-	out, err := bclient.ReceiveTaskRuns(config.CurrentProject.Name, args[0], time.Minute*3, qops)
+	out, err := bclient.ReceiveTaskRuns(ss.Project.Name, args[0], time.Minute*3, qops)
 	if err != nil {
 		HandleError(err)
 	}

--- a/command/task_stop.go
+++ b/command/task_stop.go
@@ -2,49 +2,28 @@ package command
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
-	"github.com/nerdalize/nerd/nerd/conf"
 	"github.com/pkg/errors"
 )
-
-//TaskStopOpts describes command options
-type TaskStopOpts struct {
-	NerdOpts
-}
 
 //TaskStop command
 type TaskStop struct {
 	*command
-	opts   *TaskStopOpts
-	parser *flags.Parser
 }
 
 //TaskStopFactory returns a factory method for the join command
 func TaskStopFactory() (cli.Command, error) {
-	cmd := &TaskStop{
-		command: &command{
-			help:     "",
-			synopsis: "abort any run(s) of the specified task on a queue",
-			parser:   flags.NewNamedParser("nerd task stop <queue-id> <task-id>", flags.Default),
-			ui: &cli.BasicUi{
-				Reader: os.Stdin,
-				Writer: os.Stderr,
-			},
-		},
-
-		opts: &TaskStopOpts{},
-	}
-
-	cmd.runFunc = cmd.DoRun
-	_, err := cmd.command.parser.AddGroup("options", "options", cmd.opts)
+	comm, err := newCommand("nerd task stop <queue-id> <task-id>", "abort any run(s) of the specified task on a queue", "", nil)
 	if err != nil {
-		panic(err)
+		return nil, errors.Wrap(err, "failed to create command")
 	}
+	cmd := &TaskStop{
+		command: comm,
+	}
+	cmd.runFunc = cmd.DoRun
 
 	return cmd, nil
 }
@@ -55,12 +34,7 @@ func (cmd *TaskStop) DoRun(args []string) (err error) {
 		return fmt.Errorf("not enough arguments, see --help")
 	}
 
-	config, err := conf.Read()
-	if err != nil {
-		HandleError(err)
-	}
-
-	bclient, err := NewClient(cmd.ui)
+	bclient, err := NewClient(cmd.ui, cmd.config, cmd.session)
 	if err != nil {
 		HandleError(err)
 	}
@@ -70,7 +44,11 @@ func (cmd *TaskStop) DoRun(args []string) (err error) {
 		HandleError(errors.Wrap(err, "invalid task ID, must be a number"))
 	}
 
-	out, err := bclient.StopTask(config.CurrentProject.Name, args[0], taskID)
+	ss, err := cmd.session.Read()
+	if err != nil {
+		HandleError(err)
+	}
+	out, err := bclient.StopTask(ss.Project.Name, args[0], taskID)
 	if err != nil {
 		HandleError(err)
 	}

--- a/command/utils.go
+++ b/command/utils.go
@@ -30,11 +30,7 @@ func (kw *stdoutkw) Write(k string) (err error) {
 }
 
 //NewClient creates a new batch Client.
-func NewClient(ui cli.Ui) (*v1batch.Client, error) {
-	c, err := conf.Read()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to read config")
-	}
+func NewClient(ui cli.Ui, c *conf.Config, session *conf.Session) (*v1batch.Client, error) {
 	key, err := jwt.ParseECDSAPublicKeyFromPemBytes([]byte(c.Auth.PublicKey))
 	if err != nil {
 		return nil, errors.Wrap(err, "ECDSA Public Key is invalid")
@@ -54,11 +50,11 @@ func NewClient(ui cli.Ui) (*v1batch.Client, error) {
 	return v1batch.NewClient(v1batch.ClientConfig{
 		JWTProvider: v1batch.NewChainedJWTProvider(
 			jwt.NewEnvProvider(key),
-			jwt.NewConfigProvider(key),
-			jwt.NewAuthAPIProvider(key, v1auth.NewClient(v1auth.ClientConfig{
+			jwt.NewConfigProvider(key, session),
+			jwt.NewAuthAPIProvider(key, session, v1auth.NewClient(v1auth.ClientConfig{
 				Base:               authbase,
 				Logger:             logrus.StandardLogger(),
-				OAuthTokenProvider: oauth.NewConfigProvider(authOpsClient),
+				OAuthTokenProvider: oauth.NewConfigProvider(authOpsClient, c.Auth.ClientID, session),
 			})),
 		),
 		Base:   base,

--- a/command/worker.go
+++ b/command/worker.go
@@ -1,10 +1,8 @@
 package command
 
 import (
-	"os"
-
-	flags "github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
+	"github.com/pkg/errors"
 )
 
 //Worker command
@@ -14,19 +12,15 @@ type Worker struct {
 
 //WorkerFactory returns a factory method for the join command
 func WorkerFactory() (cli.Command, error) {
-	cmd := &Worker{
-		command: &command{
-			help:     `control compute capacity for working on tasks`,
-			synopsis: "control compute capacity for working on tasks",
-			parser:   flags.NewNamedParser("nerd task", flags.Default),
-			ui: &cli.BasicUi{
-				Reader: os.Stdin,
-				Writer: os.Stderr,
-			},
-		},
+	comm, err := newCommand("nerd worker <subcommand>", "control compute capacity for working on tasks", "", nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create command")
 	}
-
+	cmd := &Worker{
+		command: comm,
+	}
 	cmd.runFunc = cmd.DoRun
+
 	return cmd, nil
 }
 

--- a/command/worker_start.go
+++ b/command/worker_start.go
@@ -11,6 +11,7 @@ import (
 //WorkerStartOpts describes command options
 type WorkerStartOpts struct {
 	NerdOpts
+	Verb func(bool) `short:"a" long:"verb" default:"false" optional:"true" optional-value:"true" description:"show verbose output"`
 }
 
 //WorkerStart command
@@ -34,6 +35,10 @@ func WorkerStartFactory() (cli.Command, error) {
 		},
 
 		opts: &WorkerStartOpts{},
+	}
+
+	cmd.opts.Verb = func(set bool) {
+		fmt.Println("!!!!!", set)
 	}
 
 	cmd.runFunc = cmd.DoRun

--- a/command/worker_start.go
+++ b/command/worker_start.go
@@ -2,50 +2,26 @@ package command
 
 import (
 	"fmt"
-	"os"
 
-	"github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
+	"github.com/pkg/errors"
 )
-
-//WorkerStartOpts describes command options
-type WorkerStartOpts struct {
-	NerdOpts
-	Verb func(bool) `short:"a" long:"verb" default:"false" optional:"true" optional-value:"true" description:"show verbose output"`
-}
 
 //WorkerStart command
 type WorkerStart struct {
 	*command
-	opts   *WorkerStartOpts
-	parser *flags.Parser
 }
 
 //WorkerStartFactory returns a factory method for the join command
 func WorkerStartFactory() (cli.Command, error) {
-	cmd := &WorkerStart{
-		command: &command{
-			help:     "",
-			synopsis: "provision a new worker to provide compute",
-			parser:   flags.NewNamedParser("nerd worker start", flags.Default),
-			ui: &cli.BasicUi{
-				Reader: os.Stdin,
-				Writer: os.Stderr,
-			},
-		},
-
-		opts: &WorkerStartOpts{},
-	}
-
-	cmd.opts.Verb = func(set bool) {
-		fmt.Println("!!!!!", set)
-	}
-
-	cmd.runFunc = cmd.DoRun
-	_, err := cmd.command.parser.AddGroup("options", "options", cmd.opts)
+	comm, err := newCommand("nerd worker start", "provision a new worker to provide compute", "", nil)
 	if err != nil {
-		panic(err)
+		return nil, errors.Wrap(err, "failed to create command")
 	}
+	cmd := &WorkerStart{
+		command: comm,
+	}
+	cmd.runFunc = cmd.DoRun
 
 	return cmd, nil
 }

--- a/command/worker_stop.go
+++ b/command/worker_stop.go
@@ -2,45 +2,26 @@ package command
 
 import (
 	"fmt"
-	"os"
 
-	"github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
+	"github.com/pkg/errors"
 )
-
-//WorkerStopOpts describes command options
-type WorkerStopOpts struct {
-	NerdOpts
-}
 
 //WorkerStop command
 type WorkerStop struct {
 	*command
-	opts   *WorkerStopOpts
-	parser *flags.Parser
 }
 
 //WorkerStopFactory returns a factory method for the join command
 func WorkerStopFactory() (cli.Command, error) {
-	cmd := &WorkerStop{
-		command: &command{
-			help:     "",
-			synopsis: "stop a worker from providing compute capacity",
-			parser:   flags.NewNamedParser("nerd worker stop", flags.Default),
-			ui: &cli.BasicUi{
-				Reader: os.Stdin,
-				Writer: os.Stderr,
-			},
-		},
-
-		opts: &WorkerStopOpts{},
-	}
-
-	cmd.runFunc = cmd.DoRun
-	_, err := cmd.command.parser.AddGroup("options", "options", cmd.opts)
+	comm, err := newCommand("nerd worker stop", "stop a worker from providing compute capacity", "", nil)
 	if err != nil {
-		panic(err)
+		return nil, errors.Wrap(err, "failed to create command")
 	}
+	cmd := &WorkerStop{
+		command: comm,
+	}
+	cmd.runFunc = cmd.DoRun
 
 	return cmd, nil
 }

--- a/main.go
+++ b/main.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	flags "github.com/jessevdk/go-flags"
 	"github.com/nerdalize/nerd/command"
 	"github.com/nerdalize/nerd/nerd"
-	"github.com/nerdalize/nerd/nerd/conf"
 
 	"github.com/mitchellh/cli"
 )
@@ -19,13 +17,8 @@ var (
 )
 
 func init() {
-	opts := new(command.ConfOpts)
-	_, err := flags.NewParser(opts, flags.None).ParseArgs(os.Args[1:])
-	if err == nil {
-		conf.SetLocation(opts.ConfigFile)
-		nerd.SetupLogging(opts.VerboseOutput, opts.JSONOutput)
-		nerd.VersionMessage(version)
-	}
+	nerd.SetupLogging()
+	nerd.VersionMessage(version)
 }
 
 func main() {

--- a/nerd/conf/conf.go
+++ b/nerd/conf/conf.go
@@ -8,10 +8,8 @@ package conf
 import (
 	"encoding/json"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"sync"
-	"time"
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
@@ -31,11 +29,9 @@ func init() {
 
 //Config is the structure that describes how the config file looks.
 type Config struct {
-	Auth            AuthConfig           `json:"auth"`
-	Credentials     CredentialsConfig    `json:"credentials"`
-	EnableLogging   bool                 `json:"enable_logging"`
-	CurrentProject  CurrentProjectConfig `json:"current_project"`
-	NerdAPIEndpoint string               `json:"nerd_api_endpoint"`
+	Auth            AuthConfig `json:"auth"`
+	EnableLogging   bool       `json:"enable_logging"`
+	NerdAPIEndpoint string     `json:"nerd_api_endpoint"`
 }
 
 //AuthConfig contains config details with respect to the authentication server.
@@ -45,33 +41,6 @@ type AuthConfig struct {
 	ClientID         string `json:"client_id"`
 	OAuthSuccessURL  string `json:"oauth_success_url"`
 	OAuthLocalServer string `json:"nerd_oauth_localserver"`
-}
-
-//CredentialsConfig contains oauth and jwt credentials
-type CredentialsConfig struct {
-	OAuth OAuthConfig `json:"oauth,omitempty"`
-	JWT   JWTConfig   `json:"jwt,omitempty"`
-}
-
-//OAuthConfig contians oauth credentials
-type OAuthConfig struct {
-	AccessToken  string    `json:"access_token"`
-	RefreshToken string    `json:"refresh_token"`
-	Expiration   time.Time `json:"expiration"`
-	Scope        string    `json:"scope"`
-	TokenType    string    `json:"token_type"`
-}
-
-//JWTConfig contains JWT credentials
-type JWTConfig struct {
-	Token        string `json:"token"`
-	RefreshToken string `json:"refresh_token"`
-}
-
-//CurrentProjectConfig contains details of the current working project.
-type CurrentProjectConfig struct {
-	Name      string `json:"current_project"`
-	AWSRegion string `json:"aws_region"`
 }
 
 //Defaults provides the default for when the config file misses certain fields.
@@ -88,58 +57,23 @@ kyvc4LwKZ8pez5KYY76H1ox+AfUlWOEq+bExypcFfEIrJkf/JXa7jpzkOWBDF9Sa
 OWbQHMK+vvUXieCJvCc9Vj084ABwLBgX
 -----END PUBLIC KEY-----`,
 		},
-		EnableLogging: false,
-		CurrentProject: CurrentProjectConfig{
-			Name:      "projectx",
-			AWSRegion: "eu-west-1",
-		},
+		EnableLogging:   false,
 		NerdAPIEndpoint: "https://batch.nerdalize.com/v1",
 	}
 }
 
-//SetLocation sets the location of the config file.
-func SetLocation(file string) error {
-	if file == "" {
-		return SetDefaultLocation()
-	}
-	location = file
-	return nil
-}
-
-//SetDefaultLocation sets the location to ~/.nerd/config.json
-func SetDefaultLocation() error {
+//GetDefaultLocation sets the location to ~/.nerd/session.json
+func GetDefaultConfigLocation() (string, error) {
 	dir, err := homedir.Dir()
 	if err != nil {
-		return errors.Wrap(err, "failed to get home dir")
+		return "", errors.Wrap(err, "failed to find home dir")
 	}
-	location = filepath.Join(dir, ".nerd", "config.json")
-	return nil
+	return filepath.Join(dir, ".nerd", "config.json"), nil
 }
 
-//GetLocation gets the location and sets it to default it is unset.
-func GetLocation() (string, error) {
-	if location == "" {
-		err := SetDefaultLocation()
-		if err != nil {
-			return "", errors.Wrap(err, "failed to set default config location")
-		}
-	}
-	return location, nil
-}
-
-//read reads the config either from memory or from disk for the first time.
-func read() (*Config, error) {
-	if conf != nil {
-		return conf, nil
-	}
-	loc, err := GetLocation()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get config location")
-	}
-	content, err := ioutil.ReadFile(loc)
-	if err != nil && os.IsNotExist(err) {
-		return Defaults(), nil
-	}
+//Read reads the config file
+func Read(location string) (*Config, error) {
+	content, err := ioutil.ReadFile(location)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open config file")
 	}
@@ -149,75 +83,4 @@ func read() (*Config, error) {
 		return nil, errors.Wrap(err, "failed to parse config file")
 	}
 	return conf, nil
-}
-
-//write writes the conf variable to disk.
-func write() error {
-	loc, err := GetLocation()
-	if err != nil {
-		return errors.Wrap(err, "failed to get config location")
-	}
-	c, err := read()
-	if err != nil {
-		return errors.Wrap(err, "failed to read config")
-	}
-	f, err := os.Create(loc)
-	if err != nil {
-		return errors.Wrap(err, "failed to create/open config file")
-	}
-	enc := json.NewEncoder(f)
-	enc.SetIndent("", "\t")
-	err = enc.Encode(c)
-	if err != nil {
-		return errors.Wrap(err, "failed to encode json")
-	}
-	return nil
-}
-
-//Read reads the config file
-func Read() (*Config, error) {
-	mut.Lock()
-	defer mut.Unlock()
-	return read()
-}
-
-//WriteJWT writes the JWT to the config file
-func WriteProject(project string) error {
-	mut.Lock()
-	defer mut.Unlock()
-	c, err := read()
-	if err != nil {
-		return errors.Wrap(err, "failed to read config")
-	}
-	c.CurrentProject.Name = project
-	return write()
-}
-
-//WriteJWT writes the JWT to the config file
-func WriteJWT(jwt, refreshToken string) error {
-	mut.Lock()
-	defer mut.Unlock()
-	c, err := read()
-	if err != nil {
-		return errors.Wrap(err, "failed to read config")
-	}
-	c.Credentials.JWT.Token = jwt
-	c.Credentials.JWT.RefreshToken = refreshToken
-	return write()
-}
-
-//WriteOAuth writes oauth credentials to the config file
-func WriteOAuth(accessToken, refreshToken string, expiration time.Time, scope, tokenType string) error {
-	mut.Lock()
-	defer mut.Unlock()
-	c, err := read()
-	if err != nil {
-		return errors.Wrap(err, "failed to read config")
-	}
-	c.Credentials.OAuth.AccessToken = accessToken
-	c.Credentials.OAuth.RefreshToken = refreshToken
-	c.Credentials.OAuth.Expiration = expiration
-	c.Credentials.OAuth.Scope = scope
-	c.Credentials.OAuth.TokenType = tokenType
-	return write()
 }

--- a/nerd/conf/conf.go
+++ b/nerd/conf/conf.go
@@ -40,7 +40,7 @@ type AuthConfig struct {
 	PublicKey        string `json:"public_key"`
 	ClientID         string `json:"client_id"`
 	OAuthSuccessURL  string `json:"oauth_success_url"`
-	OAuthLocalServer string `json:"nerd_oauth_localserver"`
+	OAuthLocalServer string `json:"oauth_localserver"`
 }
 
 //Defaults provides the default for when the config file misses certain fields.

--- a/nerd/conf/conf.go
+++ b/nerd/conf/conf.go
@@ -9,23 +9,10 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"path/filepath"
-	"sync"
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 )
-
-//location is the file location of the config file.
-var location string
-
-//conf is an in-memory representation of the config file.
-var conf *Config
-
-var mut *sync.Mutex
-
-func init() {
-	mut = &sync.Mutex{}
-}
 
 //Config is the structure that describes how the config file looks.
 type Config struct {
@@ -62,7 +49,7 @@ OWbQHMK+vvUXieCJvCc9Vj084ABwLBgX
 	}
 }
 
-//GetDefaultLocation sets the location to ~/.nerd/session.json
+//GetDefaultConfigLocation sets the location to ~/.nerd/config.json
 func GetDefaultConfigLocation() (string, error) {
 	dir, err := homedir.Dir()
 	if err != nil {
@@ -77,7 +64,7 @@ func Read(location string) (*Config, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open config file")
 	}
-	conf = Defaults()
+	conf := Defaults()
 	err = json.Unmarshal(content, conf)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse config file")

--- a/nerd/conf/conf_test.go
+++ b/nerd/conf/conf_test.go
@@ -20,8 +20,7 @@ func TestFromFile(t *testing.T) {
 		t.Fatalf("Unexpected error for temp file: %v", err)
 	}
 	temp.WriteString(testConf)
-	SetLocation(temp.Name())
-	conf, err := Read()
+	conf, err := Read(temp.Name())
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/nerd/conf/session.go
+++ b/nerd/conf/session.go
@@ -41,8 +41,8 @@ type JWT struct {
 
 //ProjectConfig contains details of the current working project.
 type Project struct {
-	Name      string `json:"name"`
-	AWSRegion string `json:"aws_region"`
+	Name      string `json:"name,omitempty"`
+	AWSRegion string `json:"aws_region,omitempty"`
 }
 
 type Session struct {

--- a/nerd/conf/session.go
+++ b/nerd/conf/session.go
@@ -1,0 +1,164 @@
+package conf
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/pkg/errors"
+)
+
+const (
+	//DefaultAWSRegion can be used to set the project region
+	DefaultAWSRegion = "eu-west-1"
+)
+
+//Config is the structure that describes how the config file looks.
+type SessionSnapshot struct {
+	OAuth   OAuth   `json:"oauth,omitempty"`
+	JWT     JWT     `json:"jwt,omitempty"`
+	Project Project `json:"project,omitempty"`
+}
+
+//OAuthConfig contians oauth credentials
+type OAuth struct {
+	AccessToken  string    `json:"access_token,omitempty"`
+	RefreshToken string    `json:"refresh_token,omitempty"`
+	Expiration   time.Time `json:"expiration,omitempty"`
+	Scope        string    `json:"scope,omitempty"`
+	TokenType    string    `json:"token_type,omitempty"`
+}
+
+//JWTConfig contains JWT credentials
+type JWT struct {
+	Token        string `json:"token,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+}
+
+//ProjectConfig contains details of the current working project.
+type Project struct {
+	Name      string `json:"name"`
+	AWSRegion string `json:"aws_region"`
+}
+
+type Session struct {
+	location string
+	m        *sync.Mutex
+}
+
+var _ SessionInterface = &Session{}
+
+func NewSession(loc string) *Session {
+	return &Session{
+		location: loc,
+		m:        &sync.Mutex{},
+	}
+}
+
+//GetDefaultLocation sets the location to ~/.nerd/session.json
+func GetDefaultSessionLocation() (string, error) {
+	dir, err := homedir.Dir()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to find home dir")
+	}
+	return filepath.Join(dir, ".nerd", "session.json"), nil
+}
+
+type SessionInterface interface {
+	Read() (*SessionSnapshot, error)
+	WriteJWT(jwt, refreshToken string) error
+	WriteOAuth(accessToken, refreshToken string, expiration time.Time, scope, tokenType string) error
+	WriteProject(project, awsRegion string) error
+}
+
+func (s *Session) readFile() (*SessionSnapshot, error) {
+	ss := &SessionSnapshot{}
+	content, err := ioutil.ReadFile(s.location)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to open config file")
+	}
+	err = json.Unmarshal(content, ss)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse config file")
+	}
+	return ss, nil
+}
+
+func (c *Session) write(ss *SessionSnapshot) error {
+	f, err := os.Create(c.location)
+	if err != nil {
+		return errors.Wrap(err, "failed to create/open config file")
+	}
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "\t")
+	err = enc.Encode(ss)
+	if err != nil {
+		return errors.Wrap(err, "failed to encode json")
+	}
+	return nil
+}
+
+func (c *Session) Read() (*SessionSnapshot, error) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	ss, err := c.readFile()
+	if err != nil {
+		return nil, err
+	}
+	return ss, nil
+}
+
+func (c *Session) WriteJWT(jwt, refreshToken string) error {
+	c.m.Lock()
+	defer c.m.Unlock()
+	ss, err := c.readFile()
+	if err != nil {
+		return errors.Wrap(err, "failed to read config")
+	}
+	ss.JWT.Token = jwt
+	ss.JWT.RefreshToken = refreshToken
+	err = c.write(ss)
+	if err != nil {
+		return errors.Wrap(err, "failed to write config")
+	}
+	return nil
+}
+
+func (c *Session) WriteOAuth(accessToken, refreshToken string, expiration time.Time, scope, tokenType string) error {
+	c.m.Lock()
+	defer c.m.Unlock()
+	ss, err := c.readFile()
+	if err != nil {
+		return errors.Wrap(err, "failed to read config")
+	}
+	ss.OAuth.AccessToken = accessToken
+	ss.OAuth.RefreshToken = refreshToken
+	ss.OAuth.Expiration = expiration
+	ss.OAuth.Scope = scope
+	ss.OAuth.TokenType = tokenType
+	err = c.write(ss)
+	if err != nil {
+		return errors.Wrap(err, "failed to write config")
+	}
+	return nil
+}
+
+func (c *Session) WriteProject(name, awsRegion string) error {
+	c.m.Lock()
+	defer c.m.Unlock()
+	ss, err := c.readFile()
+	if err != nil {
+		return errors.Wrap(err, "failed to read config")
+	}
+	ss.Project.Name = name
+	ss.Project.AWSRegion = awsRegion
+	err = c.write(ss)
+	if err != nil {
+		return errors.Wrap(err, "failed to write config")
+	}
+	return nil
+}

--- a/nerd/conf/session.go
+++ b/nerd/conf/session.go
@@ -17,14 +17,14 @@ const (
 	DefaultAWSRegion = "eu-west-1"
 )
 
-//Config is the structure that describes how the config file looks.
+//SessionSnapshot is a snapshot of the session file
 type SessionSnapshot struct {
 	OAuth   OAuth   `json:"oauth,omitempty"`
 	JWT     JWT     `json:"jwt,omitempty"`
 	Project Project `json:"project,omitempty"`
 }
 
-//OAuthConfig contians oauth credentials
+//OAuth contians oauth credentials
 type OAuth struct {
 	AccessToken  string    `json:"access_token,omitempty"`
 	RefreshToken string    `json:"refresh_token,omitempty"`
@@ -33,25 +33,28 @@ type OAuth struct {
 	TokenType    string    `json:"token_type,omitempty"`
 }
 
-//JWTConfig contains JWT credentials
+//JWT contains JWT credentials
 type JWT struct {
 	Token        string `json:"token,omitempty"`
 	RefreshToken string `json:"refresh_token,omitempty"`
 }
 
-//ProjectConfig contains details of the current working project.
+//Project contains details of the current working project.
 type Project struct {
 	Name      string `json:"name,omitempty"`
 	AWSRegion string `json:"aws_region,omitempty"`
 }
 
+//Session is an object capable of reading and writing the session file
 type Session struct {
 	location string
 	m        *sync.Mutex
 }
 
+//_ is used to make sure Session implements SessionInterface
 var _ SessionInterface = &Session{}
 
+//NewSession creates a new Session
 func NewSession(loc string) *Session {
 	return &Session{
 		location: loc,
@@ -59,7 +62,7 @@ func NewSession(loc string) *Session {
 	}
 }
 
-//GetDefaultLocation sets the location to ~/.nerd/session.json
+//GetDefaultSessionLocation sets the location to ~/.nerd/session.json
 func GetDefaultSessionLocation() (string, error) {
 	dir, err := homedir.Dir()
 	if err != nil {
@@ -68,6 +71,7 @@ func GetDefaultSessionLocation() (string, error) {
 	return filepath.Join(dir, ".nerd", "session.json"), nil
 }
 
+//SessionInterface is the interface of Session
 type SessionInterface interface {
 	Read() (*SessionSnapshot, error)
 	WriteJWT(jwt, refreshToken string) error
@@ -75,6 +79,7 @@ type SessionInterface interface {
 	WriteProject(project, awsRegion string) error
 }
 
+//readFile reads the session file
 func (s *Session) readFile() (*SessionSnapshot, error) {
 	ss := &SessionSnapshot{}
 	content, err := ioutil.ReadFile(s.location)
@@ -88,8 +93,9 @@ func (s *Session) readFile() (*SessionSnapshot, error) {
 	return ss, nil
 }
 
-func (c *Session) write(ss *SessionSnapshot) error {
-	f, err := os.Create(c.location)
+//write writes a SessionSnapshot to the session file
+func (s *Session) write(ss *SessionSnapshot) error {
+	f, err := os.Create(s.location)
 	if err != nil {
 		return errors.Wrap(err, "failed to create/open config file")
 	}
@@ -102,36 +108,39 @@ func (c *Session) write(ss *SessionSnapshot) error {
 	return nil
 }
 
-func (c *Session) Read() (*SessionSnapshot, error) {
-	c.m.Lock()
-	defer c.m.Unlock()
-	ss, err := c.readFile()
+//Read returns a snapshot of the session file
+func (s *Session) Read() (*SessionSnapshot, error) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	ss, err := s.readFile()
 	if err != nil {
 		return nil, err
 	}
 	return ss, nil
 }
 
-func (c *Session) WriteJWT(jwt, refreshToken string) error {
-	c.m.Lock()
-	defer c.m.Unlock()
-	ss, err := c.readFile()
+//WriteJWT writes the jwt object to the session file
+func (s *Session) WriteJWT(jwt, refreshToken string) error {
+	s.m.Lock()
+	defer s.m.Unlock()
+	ss, err := s.readFile()
 	if err != nil {
 		return errors.Wrap(err, "failed to read config")
 	}
 	ss.JWT.Token = jwt
 	ss.JWT.RefreshToken = refreshToken
-	err = c.write(ss)
+	err = s.write(ss)
 	if err != nil {
 		return errors.Wrap(err, "failed to write config")
 	}
 	return nil
 }
 
-func (c *Session) WriteOAuth(accessToken, refreshToken string, expiration time.Time, scope, tokenType string) error {
-	c.m.Lock()
-	defer c.m.Unlock()
-	ss, err := c.readFile()
+//WriteOAuth writes the oauth object to the session file
+func (s *Session) WriteOAuth(accessToken, refreshToken string, expiration time.Time, scope, tokenType string) error {
+	s.m.Lock()
+	defer s.m.Unlock()
+	ss, err := s.readFile()
 	if err != nil {
 		return errors.Wrap(err, "failed to read config")
 	}
@@ -140,23 +149,24 @@ func (c *Session) WriteOAuth(accessToken, refreshToken string, expiration time.T
 	ss.OAuth.Expiration = expiration
 	ss.OAuth.Scope = scope
 	ss.OAuth.TokenType = tokenType
-	err = c.write(ss)
+	err = s.write(ss)
 	if err != nil {
 		return errors.Wrap(err, "failed to write config")
 	}
 	return nil
 }
 
-func (c *Session) WriteProject(name, awsRegion string) error {
-	c.m.Lock()
-	defer c.m.Unlock()
-	ss, err := c.readFile()
+//WriteProject writes the project object to the session file
+func (s *Session) WriteProject(name, awsRegion string) error {
+	s.m.Lock()
+	defer s.m.Unlock()
+	ss, err := s.readFile()
 	if err != nil {
 		return errors.Wrap(err, "failed to read config")
 	}
 	ss.Project.Name = name
 	ss.Project.AWSRegion = awsRegion
-	err = c.write(ss)
+	err = s.write(ss)
 	if err != nil {
 		return errors.Wrap(err, "failed to write config")
 	}

--- a/nerd/jwt/authapi_provider.go
+++ b/nerd/jwt/authapi_provider.go
@@ -17,17 +17,19 @@ const (
 type AuthAPIProvider struct {
 	*ProviderBasis
 
-	Client *v1auth.Client
+	Client  *v1auth.Client
+	Session conf.SessionInterface
 }
 
 //NewAuthAPIProvider creates a new AuthAPIProvider provider.
-func NewAuthAPIProvider(pub *ecdsa.PublicKey, c *v1auth.Client) *AuthAPIProvider {
+func NewAuthAPIProvider(pub *ecdsa.PublicKey, session conf.SessionInterface, c *v1auth.Client) *AuthAPIProvider {
 	return &AuthAPIProvider{
 		ProviderBasis: &ProviderBasis{
 			ExpireWindow: DefaultExpireWindow,
 			Pub:          pub,
 		},
-		Client: c,
+		Client:  c,
+		Session: session,
 	}
 }
 
@@ -41,7 +43,7 @@ func (p *AuthAPIProvider) Retrieve() (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "failed to set expiration")
 	}
-	err = conf.WriteJWT(out.Token, "")
+	err = p.Session.WriteJWT(out.Token, "")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to write nerd jwt to config")
 	}

--- a/nerd/jwt/config_provider.go
+++ b/nerd/jwt/config_provider.go
@@ -10,30 +10,32 @@ import (
 //ConfigProvider provides a JWT from the config file. For the default file location please see TokenFilename().
 type ConfigProvider struct {
 	*ProviderBasis
+	Session conf.SessionInterface
 }
 
 //NewConfigProvider creates a new ConfigProvider provider.
-func NewConfigProvider(pub *ecdsa.PublicKey) *ConfigProvider {
+func NewConfigProvider(pub *ecdsa.PublicKey, session conf.SessionInterface) *ConfigProvider {
 	return &ConfigProvider{
 		ProviderBasis: &ProviderBasis{
 			ExpireWindow: DefaultExpireWindow,
 			Pub:          pub,
 		},
+		Session: session,
 	}
 }
 
 //Retrieve retrieves the token from the nerd config file.
 func (e *ConfigProvider) Retrieve() (string, error) {
-	c, err := conf.Read()
+	c, err := e.Session.Read()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to read config")
 	}
-	if c.Credentials.JWT.Token == "" {
+	if c.JWT.Token == "" {
 		return "", errors.New("nerd_token is not set in config")
 	}
-	err = e.SetExpirationFromJWT(c.Credentials.JWT.Token)
+	err = e.SetExpirationFromJWT(c.JWT.Token)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to set expiration")
 	}
-	return c.Credentials.JWT.Token, nil
+	return c.JWT.Token, nil
 }

--- a/nerd/log.go
+++ b/nerd/log.go
@@ -21,17 +21,10 @@ func (f *PlainFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 }
 
 //SetupLogging sets up logrus.
-func SetupLogging(verbose, json bool) {
+func SetupLogging() {
 	logrus.SetLevel(logrus.InfoLevel)
 	logrus.SetFormatter(new(PlainFormatter))
 	addFSHook()
-	if verbose {
-		logrus.SetFormatter(new(logrus.TextFormatter))
-		logrus.SetLevel(logrus.DebugLevel)
-	}
-	if json {
-		logrus.SetFormatter(new(logrus.JSONFormatter))
-	}
 }
 
 //addFSHook adds a filesystem logging hook to Logrus

--- a/nerd/log.go
+++ b/nerd/log.go
@@ -2,12 +2,8 @@ package nerd
 
 import (
 	"fmt"
-	"io"
-	"os"
 
 	"github.com/Sirupsen/logrus"
-	homedir "github.com/mitchellh/go-homedir"
-	"github.com/nerdalize/nerd/nerd/conf"
 )
 
 //PlainFormatter is a Logrus formatter that only includes the log message.
@@ -24,29 +20,4 @@ func (f *PlainFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 func SetupLogging() {
 	logrus.SetLevel(logrus.InfoLevel)
 	logrus.SetFormatter(new(PlainFormatter))
-	addFSHook()
-}
-
-//addFSHook adds a filesystem logging hook to Logrus
-func addFSHook() {
-	c, err := conf.Read()
-	if err == nil && c.EnableLogging {
-		filename, err := homedir.Expand("~/.nerd/log")
-		if err != nil {
-			return
-		}
-		f, err := os.Open(filename)
-		defer f.Close()
-		if err != nil && os.IsNotExist(err) {
-			f, err = os.Create(filename)
-			defer f.Close()
-			if err != nil {
-				return
-			}
-		}
-		if err != nil {
-			return
-		}
-		logrus.SetOutput(io.MultiWriter(os.Stdout, f))
-	}
 }

--- a/nerd/oauth/config_provider.go
+++ b/nerd/oauth/config_provider.go
@@ -19,37 +19,41 @@ var ErrTokenUnset = fmt.Errorf("ErrTokenUnset")
 //ConfigProvider provides a oauth access token from the config file. For the default file location please see TokenFilename().
 type ConfigProvider struct {
 	*ProviderBasis
-	Client *v1auth.OpsClient
+	Client        *v1auth.OpsClient
+	OAuthClientID string
+	Session       conf.SessionInterface
 }
 
 //NewConfigProvider creates a new ConfigProvider provider.
-func NewConfigProvider(client *v1auth.OpsClient) *ConfigProvider {
+func NewConfigProvider(client *v1auth.OpsClient, oauthClientID string, session conf.SessionInterface) *ConfigProvider {
 	return &ConfigProvider{
 		ProviderBasis: &ProviderBasis{
 			ExpireWindow: DefaultExpireWindow,
 		},
-		Client: client,
+		Client:        client,
+		OAuthClientID: oauthClientID,
+		Session:       session,
 	}
 }
 
 //Retrieve retrieves the token from the nerd config file.
 func (e *ConfigProvider) Retrieve() (string, error) {
-	c, err := conf.Read()
+	ss, err := e.Session.Read()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to read config")
 	}
-	if c.Credentials.OAuth.AccessToken == "" {
+	if ss.OAuth.AccessToken == "" {
 		return "", ErrTokenUnset
 	}
-	e.SetExpiration(c.Credentials.OAuth.Expiration)
+	e.SetExpiration(ss.OAuth.Expiration)
 	if e.IsExpired() {
-		token, err := e.refresh(c.Credentials.OAuth.RefreshToken, c.Auth.ClientID)
+		token, err := e.refresh(ss.OAuth.RefreshToken, e.OAuthClientID)
 		if err != nil {
 			return "", errors.Wrap(err, "failed to refresh oauth access token")
 		}
 		return token, nil
 	}
-	return c.Credentials.OAuth.AccessToken, nil
+	return ss.OAuth.AccessToken, nil
 }
 
 //refresh refreshes the oath token with the refresh token
@@ -63,7 +67,7 @@ func (e *ConfigProvider) refresh(refreshToken, clientID string) (string, error) 
 	}
 	expiration := time.Unix(e.CurrentTime().Unix()+int64(out.ExpiresIn), 0)
 	e.SetExpiration(expiration)
-	err = conf.WriteOAuth(out.AccessToken, out.RefreshToken, expiration, out.Scope, out.TokenType)
+	err = e.Session.WriteOAuth(out.AccessToken, out.RefreshToken, expiration, out.Scope, out.TokenType)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to write oauth tokens to config")
 	}


### PR DESCRIPTION
- `conf` now uses two config files: `~/.nerd/config.json` for configuration and `~/.nerd/session.jwt` for session information such as credentials
- the `command` package is refactored to automatically load the config file and initialise the session reader
- the `command` package now has a `newCommand` function
- all `Providers` now use the `conf.Session` mechanism instead of `conf.Config`