### PR TITLE
JWT Refresh logic

### DIFF
--- a/command/utils.go
+++ b/command/utils.go
@@ -47,10 +47,14 @@ func NewClient(ui cli.Ui, c *conf.Config, session *conf.Session) (*v1batch.Clien
 		Base:   authbase,
 		Logger: logrus.StandardLogger(),
 	})
+	authTokenClient := v1auth.NewTokenClient(v1auth.TokenClientConfig{
+		Base:   authbase,
+		Logger: logrus.StandardLogger(),
+	})
 	return v1batch.NewClient(v1batch.ClientConfig{
 		JWTProvider: v1batch.NewChainedJWTProvider(
-			jwt.NewEnvProvider(key),
-			jwt.NewConfigProvider(key, session),
+			jwt.NewEnvProvider(key, session, authTokenClient),
+			jwt.NewConfigProvider(key, session, authTokenClient),
 			jwt.NewAuthAPIProvider(key, session, v1auth.NewClient(v1auth.ClientConfig{
 				Base:               authbase,
 				Logger:             logrus.StandardLogger(),

--- a/nerd/client/auth/v1/client.go
+++ b/nerd/client/auth/v1/client.go
@@ -17,6 +17,8 @@ const (
 	//TokenEndpoint is the endpoint from where to fetch the JWT.
 	tokenEndpoint    = "token"
 	projectsEndpoint = "projects"
+	//NCEScope is the JWT scope for the NCE service
+	NCEScope = "nce.nerdalize.com"
 )
 
 //Client is the client for the nerdalize authentication server.
@@ -151,4 +153,11 @@ func (c *Client) GetJWT(scope string) (output *v1payload.GetJWTOutput, err error
 	output = &v1payload.GetJWTOutput{}
 	path := tokenEndpoint + "?service=" + scope
 	return output, c.doRequest(http.MethodGet, path, nil, output)
+}
+
+//GetWorkerJWT gets a new worker JWT
+func (c *Client) GetWorkerJWT(project, scope string) (output *v1payload.GetWorkerJWTOutput, err error) {
+	output = &v1payload.GetWorkerJWTOutput{}
+	path := fmt.Sprintf("%v/%v/worker/?service=%v", tokenEndpoint, project, scope)
+	return output, c.doRequest(http.MethodPost, path, nil, output)
 }

--- a/nerd/client/auth/v1/ops_client.go
+++ b/nerd/client/auth/v1/ops_client.go
@@ -37,7 +37,6 @@ func NewOpsClient(c OpsClientConfig) *OpsClient {
 
 //doRequest requests the server and decodes the output into the `output` field.
 //
-//doRequest will set the Authentication header with the JWT provided by the JWTProvider.
 //When a status code >= 400 is returned by the server the returned error will be of type HTTPError.
 func (c *OpsClient) doRequest(method, urlPath string, input, output interface{}) (err error) {
 	path, err := url.Parse(urlPath)
@@ -98,11 +97,6 @@ func (c *OpsClient) doRequest(method, urlPath string, input, output interface{})
 	}
 
 	return nil
-}
-
-//RefreshJWT refreshes a JWT with a refresh token
-func (c *OpsClient) RefreshJWT(jwt, secret string) (string, error) {
-	return "", nil
 }
 
 //GetOAuthCredentials gets oauth credentials based on a 'session' code

--- a/nerd/client/auth/v1/ops_client.go
+++ b/nerd/client/auth/v1/ops_client.go
@@ -17,6 +17,14 @@ type OpsClient struct {
 	OpsClientConfig
 }
 
+var _ OpsClientInterface = &OpsClient{}
+
+//OpsClientInterface is an interface so client calls can be mocked.
+type OpsClientInterface interface {
+	GetOAuthCredentials(code, clientID, localServerURL string) (output *v1payload.GetOAuthCredentialsOutput, err error)
+	RefreshOAuthCredentials(refreshToken, clientID string) (output *v1payload.RefreshOAuthCredentialsOutput, err error)
+}
+
 //OpsClientConfig is the config for OpsClient
 type OpsClientConfig struct {
 	Doer   Doer

--- a/nerd/client/auth/v1/payload/jwt.go
+++ b/nerd/client/auth/v1/payload/jwt.go
@@ -5,16 +5,19 @@ type GetJWTOutput struct {
 	Token string `json:"token"`
 }
 
+//GetWorkerJWTOutput is output when a worker JWT (JWT + RefreshToken) is requested
 type GetWorkerJWTOutput struct {
 	Token  string `json:"token"`
 	Secret string `json:"secret"`
 }
 
+//RefreshWorkerJWTInput is input for refreshing a JWT
 type RefreshWorkerJWTInput struct {
 	Token  string `json:"jwt"`
 	Secret string `json:"secret"`
 }
 
+//RefreshWorkerJWTOutput is output when a JWT refresh is requested
 type RefreshWorkerJWTOutput struct {
 	Token string `json:"token"`
 }

--- a/nerd/client/auth/v1/payload/jwt.go
+++ b/nerd/client/auth/v1/payload/jwt.go
@@ -4,3 +4,17 @@ package v1payload
 type GetJWTOutput struct {
 	Token string `json:"token"`
 }
+
+type GetWorkerJWTOutput struct {
+	Token  string `json:"token"`
+	Secret string `json:"secret"`
+}
+
+type RefreshWorkerJWTInput struct {
+	Token  string `json:"jwt"`
+	Secret string `json:"secret"`
+}
+
+type RefreshWorkerJWTOutput struct {
+	Token string `json:"token"`
+}

--- a/nerd/client/auth/v1/token_client.go
+++ b/nerd/client/auth/v1/token_client.go
@@ -16,6 +16,14 @@ type TokenClient struct {
 	TokenClientConfig
 }
 
+var _ TokenClientInterface = &TokenClient{}
+
+//TokenClientInterface is an interface so client calls can be mocked.
+type TokenClientInterface interface {
+	RefreshJWT(projectID, jwt, secret string) (output *v1payload.RefreshWorkerJWTOutput, err error)
+	RevokeJWT(projectID, jwt, secret string) (output *v1payload.RefreshWorkerJWTOutput, err error)
+}
+
 //TokenClientConfig is the config for TokenClient
 type TokenClientConfig struct {
 	Doer   Doer

--- a/nerd/client/auth/v1/token_client.go
+++ b/nerd/client/auth/v1/token_client.go
@@ -1,0 +1,121 @@
+package v1auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/nerdalize/nerd/nerd/client"
+	v1payload "github.com/nerdalize/nerd/nerd/client/auth/v1/payload"
+)
+
+//TokenClient is used for a bunch of operations on the auth API that don't require oauth authentication.
+type TokenClient struct {
+	TokenClientConfig
+}
+
+//TokenClientConfig is the config for TokenClient
+type TokenClientConfig struct {
+	Doer   Doer
+	Base   *url.URL
+	Logger client.Logger
+}
+
+//NewTokenClient creates a new TokenClient.
+func NewTokenClient(c TokenClientConfig) *TokenClient {
+	if c.Doer == nil {
+		c.Doer = http.DefaultClient
+	}
+	if c.Base.Path != "" && c.Base.Path[len(c.Base.Path)-1] != '/' {
+		c.Base.Path = c.Base.Path + "/"
+	}
+	return &TokenClient{c}
+}
+
+//doRequest requests the server and decodes the output into the `output` field.
+//
+//When a status code >= 400 is returned by the server the returned error will be of type HTTPError.
+func (c *TokenClient) doRequest(method, urlPath string, input, output interface{}) (err error) {
+	path, err := url.Parse(urlPath)
+	if err != nil {
+		return client.NewError("invalid url path provided", err)
+	}
+
+	resolved := c.Base.ResolveReference(path)
+
+	var req *http.Request
+	if input != nil && method != http.MethodGet {
+		buf := bytes.NewBuffer(nil)
+		enc := json.NewEncoder(buf)
+		err = enc.Encode(input)
+		if err != nil {
+			return client.NewError("failed to encode the request body", err)
+		}
+		req, err = http.NewRequest(method, resolved.String(), buf)
+		if err != nil {
+			return client.NewError("failed to create HTTP request", err)
+		}
+	} else {
+		req, err = http.NewRequest(method, resolved.String(), nil)
+		if err != nil {
+			return client.NewError("failed to create HTTP request", err)
+		}
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	client.LogRequest(req, c.Logger)
+	resp, err := c.Doer.Do(req)
+	if err != nil {
+		return client.NewError("failed to create HTTP request", err)
+	}
+	client.LogResponse(resp, c.Logger)
+
+	dec := json.NewDecoder(resp.Body)
+	defer resp.Body.Close()
+	if resp.StatusCode > 399 {
+		errv := &v1payload.Error{}
+		err = dec.Decode(errv)
+		if err != nil {
+			return client.NewError(fmt.Sprintf("failed to decode unexpected HTTP response (%s)", resp.Status), err)
+		}
+
+		return &HTTPError{
+			StatusCode: resp.StatusCode,
+			Err:        errv,
+		}
+	}
+
+	if output != nil {
+		err = dec.Decode(output)
+		if err != nil {
+			return client.NewError(fmt.Sprintf("failed to decode successfull HTTP response (%s)", resp.Status), err)
+		}
+	}
+
+	return nil
+}
+
+//RefreshJWT refreshes a JWT with a refresh token
+func (c *TokenClient) RefreshJWT(projectID, jwt, secret string) (output *v1payload.RefreshWorkerJWTOutput, err error) {
+	output = &v1payload.RefreshWorkerJWTOutput{}
+	input := &v1payload.RefreshWorkerJWTInput{
+		Token:  jwt,
+		Secret: secret,
+	}
+	path := fmt.Sprintf("%v/%v/refresh/", tokenEndpoint, projectID)
+	return output, c.doRequest(http.MethodPost, path, input, output)
+}
+
+//RevokeJWT revokes a JWT
+func (c *TokenClient) RevokeJWT(projectID, jwt, secret string) (output *v1payload.RefreshWorkerJWTOutput, err error) {
+	output = &v1payload.RefreshWorkerJWTOutput{}
+	input := &v1payload.RefreshWorkerJWTInput{
+		Token:  jwt,
+		Secret: secret,
+	}
+	path := fmt.Sprintf("%v/%v/revoke/", tokenEndpoint, projectID)
+	return output, c.doRequest(http.MethodPost, path, input, output)
+}

--- a/nerd/jwt/authapi_provider.go
+++ b/nerd/jwt/authapi_provider.go
@@ -43,6 +43,10 @@ func (p *AuthAPIProvider) Retrieve() (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "failed to set expiration")
 	}
+	err = isValid(out.Token, p.Pub)
+	if err != nil {
+		return "", err
+	}
 	err = p.Session.WriteJWT(out.Token, "")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to write nerd jwt to config")

--- a/nerd/jwt/config_provider.go
+++ b/nerd/jwt/config_provider.go
@@ -12,11 +12,11 @@ import (
 type ConfigProvider struct {
 	*ProviderBasis
 	Session conf.SessionInterface
-	Client  *v1auth.TokenClient
+	Client  v1auth.TokenClientInterface
 }
 
 //NewConfigProvider creates a new ConfigProvider provider.
-func NewConfigProvider(pub *ecdsa.PublicKey, session conf.SessionInterface, client *v1auth.TokenClient) *ConfigProvider {
+func NewConfigProvider(pub *ecdsa.PublicKey, session conf.SessionInterface, client v1auth.TokenClientInterface) *ConfigProvider {
 	return &ConfigProvider{
 		ProviderBasis: &ProviderBasis{
 			ExpireWindow: DefaultExpireWindow,
@@ -35,7 +35,7 @@ func (e *ConfigProvider) Retrieve() (string, error) {
 	}
 	jwt := ss.JWT.Token
 	if jwt == "" {
-		return "", errors.New("nerd_token is not set in config")
+		return "", errors.New(".jwt.token is not set in config")
 	}
 	err = e.SetExpirationFromJWT(jwt)
 	if err != nil {

--- a/nerd/jwt/config_provider.go
+++ b/nerd/jwt/config_provider.go
@@ -3,6 +3,7 @@ package jwt
 import (
 	"crypto/ecdsa"
 
+	v1auth "github.com/nerdalize/nerd/nerd/client/auth/v1"
 	"github.com/nerdalize/nerd/nerd/conf"
 	"github.com/pkg/errors"
 )
@@ -11,31 +12,60 @@ import (
 type ConfigProvider struct {
 	*ProviderBasis
 	Session conf.SessionInterface
+	Client  *v1auth.TokenClient
 }
 
 //NewConfigProvider creates a new ConfigProvider provider.
-func NewConfigProvider(pub *ecdsa.PublicKey, session conf.SessionInterface) *ConfigProvider {
+func NewConfigProvider(pub *ecdsa.PublicKey, session conf.SessionInterface, client *v1auth.TokenClient) *ConfigProvider {
 	return &ConfigProvider{
 		ProviderBasis: &ProviderBasis{
 			ExpireWindow: DefaultExpireWindow,
 			Pub:          pub,
 		},
 		Session: session,
+		Client:  client,
 	}
 }
 
 //Retrieve retrieves the token from the nerd config file.
 func (e *ConfigProvider) Retrieve() (string, error) {
-	c, err := e.Session.Read()
+	ss, err := e.Session.Read()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to read config")
 	}
-	if c.JWT.Token == "" {
+	jwt := ss.JWT.Token
+	if jwt == "" {
 		return "", errors.New("nerd_token is not set in config")
 	}
-	err = e.SetExpirationFromJWT(c.JWT.Token)
+	err = e.SetExpirationFromJWT(jwt)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to set expiration")
 	}
-	return c.JWT.Token, nil
+	if ss.JWT.RefreshToken != "" && e.IsExpired() {
+		jwt, err = e.refresh(jwt, ss.JWT.RefreshToken, ss.Project.Name)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to refresh")
+		}
+	}
+	err = isValid(jwt, e.Pub)
+	if err != nil {
+		return "", err
+	}
+	return jwt, nil
+}
+
+func (e *ConfigProvider) refresh(jwt, secret, projectID string) (string, error) {
+	out, err := e.Client.RefreshJWT(projectID, jwt, secret)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to refresh token")
+	}
+	err = e.SetExpirationFromJWT(out.Token)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to set expiration")
+	}
+	err = e.Session.WriteJWT(out.Token, secret)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to write jwt and secret to config")
+	}
+	return out.Token, nil
 }

--- a/nerd/jwt/env_provider.go
+++ b/nerd/jwt/env_provider.go
@@ -4,26 +4,34 @@ import (
 	"crypto/ecdsa"
 	"os"
 
+	v1auth "github.com/nerdalize/nerd/nerd/client/auth/v1"
+	"github.com/nerdalize/nerd/nerd/conf"
 	"github.com/pkg/errors"
 )
 
 const (
-	//NerdTokenEnvVar is the environment variable used to set the JWT.
+	//NerdTokenEnvVar is the environment variable used to set the JWT
 	NerdTokenEnvVar = "NERD_JWT"
+	//NerdTokenEnvVar is the environment variable used for the JWT refresh secret
+	NerdSecretEnvVar = "NERD_JWT_SECRET"
 )
 
 //EnvProvider provides nerdalize credentials from the `credentials.NerdTokenEnvVar` environment variable.
 type EnvProvider struct {
 	*ProviderBasis
+	Client  *v1auth.TokenClient
+	Session conf.SessionInterface
 }
 
 //NewEnvProvider creates a new EnvProvider provider.
-func NewEnvProvider(pub *ecdsa.PublicKey) *EnvProvider {
+func NewEnvProvider(pub *ecdsa.PublicKey, session conf.SessionInterface, client *v1auth.TokenClient) *EnvProvider {
 	return &EnvProvider{
 		ProviderBasis: &ProviderBasis{
 			ExpireWindow: DefaultExpireWindow,
 			Pub:          pub,
 		},
+		Session: session,
+		Client:  client,
 	}
 }
 
@@ -37,5 +45,37 @@ func (e *EnvProvider) Retrieve() (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "failed to set expiration")
 	}
+
+	jwtSecret := os.Getenv(NerdSecretEnvVar)
+	if jwtSecret != "" && e.IsExpired() {
+		jwt, err = e.refresh(jwt, jwtSecret)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to refresh")
+		}
+	}
+	err = isValid(jwt, e.Pub)
+	if err != nil {
+		return "", err
+	}
 	return jwt, nil
+}
+
+func (e *EnvProvider) refresh(jwt, secret string) (string, error) {
+	ss, err := e.Session.Read()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read config")
+	}
+	out, err := e.Client.RefreshJWT(ss.Project.Name, jwt, secret)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to refresh token")
+	}
+	err = e.SetExpirationFromJWT(out.Token)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to set expiration")
+	}
+	err = e.Session.WriteJWT(out.Token, secret)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to write jwt and secret to config")
+	}
+	return out.Token, nil
 }

--- a/nerd/jwt/env_provider.go
+++ b/nerd/jwt/env_provider.go
@@ -12,19 +12,19 @@ import (
 const (
 	//NerdTokenEnvVar is the environment variable used to set the JWT
 	NerdTokenEnvVar = "NERD_JWT"
-	//NerdTokenEnvVar is the environment variable used for the JWT refresh secret
+	//NerdSecretEnvVar is the environment variable used for the JWT refresh secret
 	NerdSecretEnvVar = "NERD_JWT_REFRESH_TOKEN"
 )
 
 //EnvProvider provides nerdalize credentials from the `credentials.NerdTokenEnvVar` environment variable.
 type EnvProvider struct {
 	*ProviderBasis
-	Client  *v1auth.TokenClient
+	Client  v1auth.TokenClientInterface
 	Session conf.SessionInterface
 }
 
 //NewEnvProvider creates a new EnvProvider provider.
-func NewEnvProvider(pub *ecdsa.PublicKey, session conf.SessionInterface, client *v1auth.TokenClient) *EnvProvider {
+func NewEnvProvider(pub *ecdsa.PublicKey, session conf.SessionInterface, client v1auth.TokenClientInterface) *EnvProvider {
 	return &EnvProvider{
 		ProviderBasis: &ProviderBasis{
 			ExpireWindow: DefaultExpireWindow,
@@ -72,10 +72,6 @@ func (e *EnvProvider) refresh(jwt, secret string) (string, error) {
 	err = e.SetExpirationFromJWT(out.Token)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to set expiration")
-	}
-	err = e.Session.WriteJWT(out.Token, secret)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to write jwt and secret to config")
 	}
 	return out.Token, nil
 }

--- a/nerd/jwt/env_provider.go
+++ b/nerd/jwt/env_provider.go
@@ -13,7 +13,7 @@ const (
 	//NerdTokenEnvVar is the environment variable used to set the JWT
 	NerdTokenEnvVar = "NERD_JWT"
 	//NerdTokenEnvVar is the environment variable used for the JWT refresh secret
-	NerdSecretEnvVar = "NERD_JWT_SECRET"
+	NerdSecretEnvVar = "NERD_JWT_REFRESH_TOKEN"
 )
 
 //EnvProvider provides nerdalize credentials from the `credentials.NerdTokenEnvVar` environment variable.

--- a/nerd/jwt/jwt.go
+++ b/nerd/jwt/jwt.go
@@ -67,3 +67,15 @@ func ParseECDSAPublicKeyFromPemBytes(pemb []byte) (*ecdsa.PublicKey, error) {
 		return nil, errors.New("pem bytes doesn't contain a ECDSA public key")
 	}
 }
+
+func isValid(jwt string, pub *ecdsa.PublicKey) error {
+	claims, err := DecodeTokenWithKey(jwt, pub)
+	if err != nil {
+		return errors.Wrapf(err, "failed to decode jwt '%v'", jwt)
+	}
+	err = claims.Valid()
+	if err != nil {
+		return errors.Wrapf(err, "nerd jwt '%v' is invalid", jwt)
+	}
+	return nil
+}

--- a/nerd/jwt/provider.go
+++ b/nerd/jwt/provider.go
@@ -2,6 +2,7 @@ package jwt
 
 import (
 	"crypto/ecdsa"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -36,6 +37,7 @@ func (b *ProviderBasis) SetExpiration(expiration time.Time) {
 	if b.ExpireWindow > 0 {
 		b.expiration = b.expiration.Add(-b.ExpireWindow)
 	}
+	fmt.Println()
 }
 
 //SetExpirationFromJWT decodes the JWT and sets the provider expiration based on the JWT expiration field.

--- a/nerd/jwt/provider.go
+++ b/nerd/jwt/provider.go
@@ -47,9 +47,5 @@ func (b *ProviderBasis) SetExpirationFromJWT(jwt string) error {
 
 	b.AlwaysValid = claims.ExpiresAt == 0 // if unset
 	b.SetExpiration(time.Unix(claims.ExpiresAt, 0))
-	err = claims.Valid()
-	if err != nil {
-		return errors.Wrapf(err, "nerd jwt '%v' is invalid", jwt)
-	}
 	return nil
 }

--- a/nerd/jwt/test_utils.go
+++ b/nerd/jwt/test_utils.go
@@ -1,0 +1,59 @@
+package jwt
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"fmt"
+	"testing"
+	"time"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	v1payload "github.com/nerdalize/nerd/nerd/client/auth/v1/payload"
+)
+
+const (
+	minute = 60
+)
+
+//testkey creates a new ecdsa keypair.
+func testkey(t *testing.T) *ecdsa.PrivateKey {
+	k, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate test key: %v", err)
+	}
+	return k
+}
+
+//tokenAndPub returns a token string and public key.
+func getToken(key *ecdsa.PrivateKey, claims *jwt.StandardClaims, t *testing.T) string {
+	token := jwt.NewWithClaims(jwt.SigningMethodES384, claims)
+	ss, err := token.SignedString(key)
+	if err != nil {
+		t.Fatalf("failed to sign claims: %v", err)
+	}
+	return ss
+}
+
+type tokenClient struct {
+	token string
+}
+
+//RefreshJWT refreshes a JWT with a refresh token
+func (c *tokenClient) RefreshJWT(projectID, jwt, secret string) (output *v1payload.RefreshWorkerJWTOutput, err error) {
+	output = &v1payload.RefreshWorkerJWTOutput{
+		Token: c.token,
+	}
+	return output, nil
+}
+
+//RevokeJWT revokes a JWT
+func (c *tokenClient) RevokeJWT(projectID, jwt, secret string) (output *v1payload.RefreshWorkerJWTOutput, err error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func timeFunc(t time.Time) func() time.Time {
+	return func() time.Time {
+		return t
+	}
+}

--- a/nerd/oauth/config_provider.go
+++ b/nerd/oauth/config_provider.go
@@ -19,13 +19,13 @@ var ErrTokenUnset = fmt.Errorf("ErrTokenUnset")
 //ConfigProvider provides a oauth access token from the config file. For the default file location please see TokenFilename().
 type ConfigProvider struct {
 	*ProviderBasis
-	Client        *v1auth.OpsClient
+	Client        v1auth.OpsClientInterface
 	OAuthClientID string
 	Session       conf.SessionInterface
 }
 
 //NewConfigProvider creates a new ConfigProvider provider.
-func NewConfigProvider(client *v1auth.OpsClient, oauthClientID string, session conf.SessionInterface) *ConfigProvider {
+func NewConfigProvider(client v1auth.OpsClientInterface, oauthClientID string, session conf.SessionInterface) *ConfigProvider {
 	return &ConfigProvider{
 		ProviderBasis: &ProviderBasis{
 			ExpireWindow: DefaultExpireWindow,

--- a/nerd/oauth/config_provider_test.go
+++ b/nerd/oauth/config_provider_test.go
@@ -1,0 +1,98 @@
+package oauth
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	v1payload "github.com/nerdalize/nerd/nerd/client/auth/v1/payload"
+	"github.com/nerdalize/nerd/nerd/conf"
+	"github.com/nerdalize/nerd/nerd/utils"
+)
+
+const (
+	minute = 60
+)
+
+var EmptyClaims = &jwt.StandardClaims{}
+
+type inMemSession struct {
+	ss *conf.SessionSnapshot
+}
+
+//Read returns a snapshot of the session file
+func (s *inMemSession) Read() (*conf.SessionSnapshot, error) {
+	return s.ss, nil
+}
+
+//WriteJWT writes the jwt object to the session file
+func (s *inMemSession) WriteJWT(jwt, refreshToken string) error {
+	return fmt.Errorf("not implemented")
+}
+
+type opsClient struct {
+	output *v1payload.RefreshOAuthCredentialsOutput
+}
+
+//GetOAuthCredentials gets oauth credentials based on a 'session' code
+func (c *opsClient) GetOAuthCredentials(code, clientID, localServerURL string) (output *v1payload.GetOAuthCredentialsOutput, err error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+//RefreshOAuthCredentials refreshes an oauth access token
+func (c *opsClient) RefreshOAuthCredentials(refreshToken, clientID string) (output *v1payload.RefreshOAuthCredentialsOutput, err error) {
+	return c.output, nil
+}
+
+//WriteOAuth writes the oauth object to the session file
+func (s *inMemSession) WriteOAuth(accessToken, refreshToken string, expiration time.Time, scope, tokenType string) error {
+	s.ss.OAuth.AccessToken = accessToken
+	s.ss.OAuth.RefreshToken = refreshToken
+	s.ss.OAuth.Expiration = expiration
+	s.ss.OAuth.Scope = scope
+	s.ss.OAuth.TokenType = tokenType
+	return nil
+}
+
+//WriteProject writes the project object to the session file
+func (s *inMemSession) WriteProject(name, awsRegion string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func TestConfigProvider(t *testing.T) {
+	session := &inMemSession{
+		ss: &conf.SessionSnapshot{},
+	}
+	refreshedCredentials := &v1payload.RefreshOAuthCredentialsOutput{
+		OAuthCredentials: v1payload.OAuthCredentials{
+			AccessToken:  "new_token",
+			RefreshToken: "new_refreshed_token",
+			ExpiresIn:    5 * minute,
+		},
+	}
+	client := &opsClient{
+		output: refreshedCredentials,
+	}
+
+	prov := NewConfigProvider(client, "", session)
+	prov.ExpireWindow = 0
+
+	t.Run("normal", func(t *testing.T) {
+		token := "default"
+		session.WriteOAuth(token, "normal_refresh", time.Now().Add(5*time.Minute), "", "")
+		ret, err := prov.Retrieve()
+		utils.OK(t, err)
+		utils.Equals(t, token, ret)
+	})
+
+	t.Run("expired", func(t *testing.T) {
+		exp := time.Now().Add(-5 * time.Minute)
+		session.WriteOAuth("default", "normal_refresh", exp, "", "")
+		ret, err := prov.Retrieve()
+		utils.OK(t, err)
+		utils.Equals(t, refreshedCredentials.AccessToken, ret)
+		utils.Assert(t, prov.expiration.Unix() > exp.Unix(), "expected new expiration date to be set", prov.expiration, exp)
+	})
+
+}

--- a/nerd/utils/test_utils.go
+++ b/nerd/utils/test_utils.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+//Assert fails the test if the condition is false.
+func Assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
+	if !condition {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: "+msg+"\033[39m\n\n", append([]interface{}{filepath.Base(file), line}, v...)...)
+		tb.FailNow()
+	}
+}
+
+//OK fails the test if an err is not nil.
+func OK(tb testing.TB, err error) {
+	if err != nil {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: unexpected error: %s\033[39m\n\n", filepath.Base(file), line, err.Error())
+		tb.FailNow()
+	}
+}
+
+//Equals fails the test if exp is not equal to act.
+func Equals(tb testing.TB, exp, act interface{}) {
+	if !reflect.DeepEqual(exp, act) {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, exp, act)
+		tb.FailNow()
+	}
+}


### PR DESCRIPTION
- jwt EnvProvider and jwt ConfigProvider now try to refresh a JWT if it's expired and a refresh token is present
- it's now possible to fetch a JWT+RefreshToken from the Auth server to pass to a worker in universe.