### PR TITLE
Project placement and worker start,list,stop

### DIFF
--- a/command/dataset.go
+++ b/command/dataset.go
@@ -16,8 +16,8 @@ type Dataset struct {
 func DatasetFactory() (cli.Command, error) {
 	cmd := &Dataset{
 		command: &command{
-			help:     `upload and download datasets for tasks to use`,
-			synopsis: "upload and download datasets for tasks to use",
+			help:     `upload and download data for tasks to use`,
+			synopsis: "upload and download data for tasks to use",
 			parser:   flags.NewNamedParser("nerd dataset <subcommand>", flags.Default),
 			ui: &cli.BasicUi{
 				Reader: os.Stdin,

--- a/command/project_expel.go
+++ b/command/project_expel.go
@@ -1,0 +1,68 @@
+package command
+
+import (
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/jessevdk/go-flags"
+	"github.com/mitchellh/cli"
+	"github.com/nerdalize/nerd/nerd/conf"
+)
+
+//ProjectExpelOps describes command options
+type ProjectExpelOps struct {
+	NerdOpts
+}
+
+//ProjectExpel command
+type ProjectExpel struct {
+	*command
+	opts   *ProjectExpelOps
+	parser *flags.Parser
+}
+
+//ProjectExpelFactory returns a factory method for the join command
+func ProjectExpelFactory() (cli.Command, error) {
+	cmd := &ProjectExpel{
+		command: &command{
+			help:     "",
+			synopsis: "expel the current project from its compute cluster",
+			parser:   flags.NewNamedParser("nerd project expel", flags.Default),
+			ui: &cli.BasicUi{
+				Reader: os.Stdin,
+				Writer: os.Stderr,
+			},
+		},
+
+		opts: &ProjectExpelOps{},
+	}
+
+	cmd.runFunc = cmd.DoRun
+	_, err := cmd.command.parser.AddGroup("options", "options", cmd.opts)
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd, nil
+}
+
+//DoRun is called by run and allows an error to be returned
+func (cmd *ProjectExpel) DoRun(args []string) (err error) {
+	config, err := conf.Read()
+	if err != nil {
+		HandleError(err)
+	}
+
+	bclient, err := NewClient(cmd.ui)
+	if err != nil {
+		HandleError(err)
+	}
+
+	out, err := bclient.ExpelProject(config.CurrentProject.Name)
+	if err != nil {
+		HandleError(err)
+	}
+
+	logrus.Infof("Placement removed: %v", out)
+	return nil
+}

--- a/command/project_place.go
+++ b/command/project_place.go
@@ -1,0 +1,73 @@
+package command
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/jessevdk/go-flags"
+	"github.com/mitchellh/cli"
+	"github.com/nerdalize/nerd/nerd/conf"
+)
+
+//ProjectPlaceOps describes command options
+type ProjectPlaceOps struct {
+	NerdOpts
+}
+
+//ProjectPlace command
+type ProjectPlace struct {
+	*command
+	opts   *ProjectPlaceOps
+	parser *flags.Parser
+}
+
+//ProjectPlaceFactory returns a factory method for the join command
+func ProjectPlaceFactory() (cli.Command, error) {
+	cmd := &ProjectPlace{
+		command: &command{
+			help:     "",
+			synopsis: "place the current project on a compute cluster",
+			parser:   flags.NewNamedParser("nerd project place <host> <token>", flags.Default),
+			ui: &cli.BasicUi{
+				Reader: os.Stdin,
+				Writer: os.Stderr,
+			},
+		},
+
+		opts: &ProjectPlaceOps{},
+	}
+
+	cmd.runFunc = cmd.DoRun
+	_, err := cmd.command.parser.AddGroup("options", "options", cmd.opts)
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd, nil
+}
+
+//DoRun is called by run and allows an error to be returned
+func (cmd *ProjectPlace) DoRun(args []string) (err error) {
+	if len(args) < 2 {
+		return fmt.Errorf("not enough arguments, see --help")
+	}
+
+	config, err := conf.Read()
+	if err != nil {
+		HandleError(err)
+	}
+
+	bclient, err := NewClient(cmd.ui)
+	if err != nil {
+		HandleError(err)
+	}
+
+	out, err := bclient.PlaceProject(config.CurrentProject.Name, args[0], args[1], "") //@TODO allow self signed certificate
+	if err != nil {
+		HandleError(err)
+	}
+
+	logrus.Infof("Placement created: %v", out)
+	return nil
+}

--- a/command/worker_list.go
+++ b/command/worker_list.go
@@ -1,0 +1,77 @@
+package command
+
+import (
+	"os"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/mitchellh/cli"
+	"github.com/nerdalize/nerd/nerd/conf"
+	"github.com/olekukonko/tablewriter"
+)
+
+//WorkerListOpts describes command options
+type WorkerListOpts struct {
+	NerdOpts
+}
+
+//WorkerList command
+type WorkerList struct {
+	*command
+	opts   *WorkerListOpts
+	parser *flags.Parser
+}
+
+//WorkerListFactory returns a factory method for the join command
+func WorkerListFactory() (cli.Command, error) {
+	cmd := &WorkerList{
+		command: &command{
+			help:     "",
+			synopsis: "show a list of all workers in the current project",
+			parser:   flags.NewNamedParser("nerd worker list", flags.Default),
+			ui: &cli.BasicUi{
+				Reader: os.Stdin,
+				Writer: os.Stderr,
+			},
+		},
+
+		opts: &WorkerListOpts{},
+	}
+
+	cmd.runFunc = cmd.DoRun
+	_, err := cmd.command.parser.AddGroup("options", "options", cmd.opts)
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd, nil
+}
+
+//DoRun is called by run and allows an error to be returned
+func (cmd *WorkerList) DoRun(args []string) (err error) {
+	config, err := conf.Read()
+	if err != nil {
+		HandleError(err)
+	}
+
+	bclient, err := NewClient(cmd.ui)
+	if err != nil {
+		HandleError(err)
+	}
+
+	out, err := bclient.ListWorkers(config.CurrentProject.Name)
+	if err != nil {
+		HandleError(err)
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"ProjectID", "WorkerID"})
+	for _, t := range out.Workers {
+		row := []string{}
+		row = append(row, t.ProjectID)
+		row = append(row, t.WorkerID)
+		table.Append(row)
+	}
+
+	table.Render()
+	return nil
+}

--- a/command/worker_start.go
+++ b/command/worker_start.go
@@ -1,11 +1,12 @@
 package command
 
 import (
-	"fmt"
 	"os"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
+	"github.com/nerdalize/nerd/nerd/conf"
 )
 
 //WorkerStartOpts describes command options
@@ -47,5 +48,21 @@ func WorkerStartFactory() (cli.Command, error) {
 
 //DoRun is called by run and allows an error to be returned
 func (cmd *WorkerStart) DoRun(args []string) (err error) {
-	return fmt.Errorf("not yet implemented")
+	config, err := conf.Read()
+	if err != nil {
+		HandleError(err)
+	}
+
+	bclient, err := NewClient(cmd.ui)
+	if err != nil {
+		HandleError(err)
+	}
+
+	worker, err := bclient.StartWorker(config.CurrentProject.Name)
+	if err != nil {
+		HandleError(err)
+	}
+
+	logrus.Infof("Worker Started: %v", worker)
+	return nil
 }

--- a/command/worker_start.go
+++ b/command/worker_start.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/Sirupsen/logrus"
@@ -27,7 +28,7 @@ func WorkerStartFactory() (cli.Command, error) {
 		command: &command{
 			help:     "",
 			synopsis: "provision a new worker to provide compute",
-			parser:   flags.NewNamedParser("nerd worker start", flags.Default),
+			parser:   flags.NewNamedParser("nerd worker start <image>", flags.Default),
 			ui: &cli.BasicUi{
 				Reader: os.Stdin,
 				Writer: os.Stderr,
@@ -48,6 +49,10 @@ func WorkerStartFactory() (cli.Command, error) {
 
 //DoRun is called by run and allows an error to be returned
 func (cmd *WorkerStart) DoRun(args []string) (err error) {
+	if len(args) < 1 {
+		return fmt.Errorf("not enough arguments, see --help")
+	}
+
 	config, err := conf.Read()
 	if err != nil {
 		HandleError(err)
@@ -58,7 +63,7 @@ func (cmd *WorkerStart) DoRun(args []string) (err error) {
 		HandleError(err)
 	}
 
-	worker, err := bclient.StartWorker(config.CurrentProject.Name)
+	worker, err := bclient.StartWorker(config.CurrentProject.Name, args[0])
 	if err != nil {
 		HandleError(err)
 	}

--- a/command/worker_stop.go
+++ b/command/worker_stop.go
@@ -6,15 +6,6 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/mitchellh/cli"
 	"github.com/pkg/errors"
-	// <<<<<<< HEAD
-	// 	"github.com/Sirupsen/logrus"
-	// 	"github.com/jessevdk/go-flags"
-	// 	"github.com/mitchellh/cli"
-	// 	"github.com/nerdalize/nerd/nerd/conf"
-	// =======
-	// 	"github.com/mitchellh/cli"
-	// 	"github.com/pkg/errors"
-	// >>>>>>> master
 )
 
 //WorkerStop command

--- a/command/worker_stop.go
+++ b/command/worker_stop.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/jessevdk/go-flags"
 	"github.com/mitchellh/cli"
+	"github.com/nerdalize/nerd/nerd/conf"
 )
 
 //WorkerStopOpts describes command options
@@ -26,7 +28,7 @@ func WorkerStopFactory() (cli.Command, error) {
 		command: &command{
 			help:     "",
 			synopsis: "stop a worker from providing compute capacity",
-			parser:   flags.NewNamedParser("nerd worker stop", flags.Default),
+			parser:   flags.NewNamedParser("nerd worker stop <worker_id>", flags.Default),
 			ui: &cli.BasicUi{
 				Reader: os.Stdin,
 				Writer: os.Stderr,
@@ -47,5 +49,25 @@ func WorkerStopFactory() (cli.Command, error) {
 
 //DoRun is called by run and allows an error to be returned
 func (cmd *WorkerStop) DoRun(args []string) (err error) {
-	return fmt.Errorf("not yet implemented")
+	if len(args) < 1 {
+		return fmt.Errorf("not enough arguments, see --help")
+	}
+
+	config, err := conf.Read()
+	if err != nil {
+		HandleError(err)
+	}
+
+	bclient, err := NewClient(cmd.ui)
+	if err != nil {
+		HandleError(err)
+	}
+
+	worker, err := bclient.StopWorker(config.CurrentProject.Name, args[0])
+	if err != nil {
+		HandleError(err)
+	}
+
+	logrus.Infof("Worker stopped: %v", worker)
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func main() {
 		"worker":           command.WorkerFactory,
 		"worker start":     command.WorkerStartFactory,
 		"worker stop":      command.WorkerStopFactory,
+		"worker list":      command.WorkerListFactory,
 		"worker work":      command.WorkerWorkFactory,
 		"dataset":          command.DatasetFactory,
 		"dataset upload":   command.DatasetUploadFactory,

--- a/main.go
+++ b/main.go
@@ -46,6 +46,8 @@ func main() {
 		"queue create":     command.QueueCreateFactory,
 		"queue delete":     command.QueueDeleteFactory,
 		"project":          command.ProjectFactory,
+		"project place":    command.ProjectPlaceFactory,
+		"project expel":    command.ProjectExpelFactory,
 		"project set":      command.ProjectSetFactory,
 		"project list":     command.ProjectListFactory,
 		"task":             command.TaskFactory,

--- a/nerd/client/batch/v1/payload/placement.go
+++ b/nerd/client/batch/v1/payload/placement.go
@@ -1,21 +1,21 @@
 package v1payload
 
-//CreatePlacementInput is input for queue creation
-type CreatePlacementInput struct {
+//PlaceProjectInput is input for queue creation
+type PlaceProjectInput struct {
 	ProjectID string `json:"project_id" valid:"required"`
 	Host      string `json:"host" valid:"required"`
 	Token     string `json:"token" valid:"required"`
 	CAPem     string `json:"ca_pem"`
 }
 
-//CreatePlacementOutput is output for queue creation
-type CreatePlacementOutput struct {
+//PlaceProjectOutput is output for queue creation
+type PlaceProjectOutput struct {
 }
 
-//DeletePlacementInput is input for queue creation
-type DeletePlacementInput struct {
+//ExpelProjectInput is input for queue creation
+type ExpelProjectInput struct {
 	ProjectID string `json:"project_id" valid:"required"`
 }
 
-//DeletePlacementOutput is output for queue creation
-type DeletePlacementOutput struct{}
+//ExpelProjectOutput is output for queue creation
+type ExpelProjectOutput struct{}

--- a/nerd/client/batch/v1/payload/worker.go
+++ b/nerd/client/batch/v1/payload/worker.go
@@ -23,8 +23,7 @@ type StopWorkerOutput struct{}
 //WorkerSummary is a smaller representation of a queue
 type WorkerSummary struct {
 	ProjectID string `json:"project_id"`
-	WorkerID  string `json:"queue_id"`
-	WorkerURL string `json:"queue_url"`
+	WorkerID  string `json:"worker_id"`
 }
 
 //ListWorkersInput is input for queue creation

--- a/nerd/client/batch/v1/payload/worker.go
+++ b/nerd/client/batch/v1/payload/worker.go
@@ -3,6 +3,7 @@ package v1payload
 //StartWorkerInput is input for queue creation
 type StartWorkerInput struct {
 	ProjectID string `json:"project_id" valid:"required"`
+	Image     string `json:"image" valid:"required"`
 }
 
 //StartWorkerOutput is output for queue creation

--- a/nerd/client/batch/v1/payload/worker.go
+++ b/nerd/client/batch/v1/payload/worker.go
@@ -19,3 +19,20 @@ type StopWorkerInput struct {
 
 //StopWorkerOutput is output for queue creation
 type StopWorkerOutput struct{}
+
+//WorkerSummary is a smaller representation of a queue
+type WorkerSummary struct {
+	ProjectID string `json:"project_id"`
+	WorkerID  string `json:"queue_id"`
+	WorkerURL string `json:"queue_url"`
+}
+
+//ListWorkersInput is input for queue creation
+type ListWorkersInput struct {
+	ProjectID string `json:"project_id" valid:"required"`
+}
+
+//ListWorkersOutput is output for queue creation
+type ListWorkersOutput struct {
+	Workers []*WorkerSummary
+}

--- a/nerd/client/batch/v1/placement.go
+++ b/nerd/client/batch/v1/placement.go
@@ -8,14 +8,14 @@ import (
 
 //ClientPlacementInterface is an interface for placement of project
 type ClientPlacementInterface interface {
-	CreatePlacement(projectID, host, token, capem string) (output *v1payload.CreatePlacementOutput, err error)
-	DeletePlacement(projectID string) (output *v1payload.DeletePlacementOutput, err error)
+	PlaceProject(projectID, host, token, capem string) (output *v1payload.PlaceProjectOutput, err error)
+	ExpelProject(projectID string) (output *v1payload.ExpelProjectOutput, err error)
 }
 
-//CreatePlacement will create queue
-func (c *Client) CreatePlacement(projectID, host, token, capem string) (output *v1payload.CreatePlacementOutput, err error) {
-	output = &v1payload.CreatePlacementOutput{}
-	input := &v1payload.CreatePlacementInput{
+//PlaceProject will create queue
+func (c *Client) PlaceProject(projectID, host, token, capem string) (output *v1payload.PlaceProjectOutput, err error) {
+	output = &v1payload.PlaceProjectOutput{}
+	input := &v1payload.PlaceProjectInput{
 		ProjectID: projectID,
 		Host:      host,
 		Token:     token,
@@ -25,10 +25,10 @@ func (c *Client) CreatePlacement(projectID, host, token, capem string) (output *
 	return output, c.doRequest(http.MethodPost, createPath(projectID, placementsEndpoint), input, output)
 }
 
-//DeletePlacement will delete queue a queue with the provided id
-func (c *Client) DeletePlacement(projectID string) (output *v1payload.DeletePlacementOutput, err error) {
-	output = &v1payload.DeletePlacementOutput{}
-	input := &v1payload.DeletePlacementInput{
+//ExpelProject will delete queue a queue with the provided id
+func (c *Client) ExpelProject(projectID string) (output *v1payload.ExpelProjectOutput, err error) {
+	output = &v1payload.ExpelProjectOutput{}
+	input := &v1payload.ExpelProjectInput{
 		ProjectID: projectID,
 	}
 

--- a/nerd/client/batch/v1/worker.go
+++ b/nerd/client/batch/v1/worker.go
@@ -8,16 +8,17 @@ import (
 
 //ClientWorkerInterface is an interface for placement of project
 type ClientWorkerInterface interface {
-	StartWorker(projectID string) (output *v1payload.StartWorkerOutput, err error)
+	StartWorker(projectID, image string) (output *v1payload.StartWorkerOutput, err error)
 	StopWorker(projectID, workerID string) (output *v1payload.StopWorkerOutput, err error)
 	ListWorkers(projectID string) (output *v1payload.ListWorkersOutput, err error)
 }
 
 //StartWorker will create worker
-func (c *Client) StartWorker(projectID string) (output *v1payload.StartWorkerOutput, err error) {
+func (c *Client) StartWorker(projectID, image string) (output *v1payload.StartWorkerOutput, err error) {
 	output = &v1payload.StartWorkerOutput{}
 	input := &v1payload.StartWorkerInput{
 		ProjectID: projectID,
+		Image:     image,
 	}
 
 	return output, c.doRequest(http.MethodPost, createPath(projectID, workersEndpoint), input, output)

--- a/nerd/client/batch/v1/worker.go
+++ b/nerd/client/batch/v1/worker.go
@@ -10,9 +10,10 @@ import (
 type ClientWorkerInterface interface {
 	StartWorker(projectID string) (output *v1payload.StartWorkerOutput, err error)
 	StopWorker(projectID, workerID string) (output *v1payload.StopWorkerOutput, err error)
+	ListWorkers(projectID string) (output *v1payload.ListWorkersOutput, err error)
 }
 
-//StartWorker will create queue
+//StartWorker will create worker
 func (c *Client) StartWorker(projectID string) (output *v1payload.StartWorkerOutput, err error) {
 	output = &v1payload.StartWorkerOutput{}
 	input := &v1payload.StartWorkerInput{
@@ -22,7 +23,7 @@ func (c *Client) StartWorker(projectID string) (output *v1payload.StartWorkerOut
 	return output, c.doRequest(http.MethodPost, createPath(projectID, workersEndpoint), input, output)
 }
 
-//StopWorker will delete queue a queue with the provided id
+//StopWorker will delete worker a worker with the provided id
 func (c *Client) StopWorker(projectID, workerID string) (output *v1payload.StopWorkerOutput, err error) {
 	output = &v1payload.StopWorkerOutput{}
 	input := &v1payload.StopWorkerInput{
@@ -31,4 +32,14 @@ func (c *Client) StopWorker(projectID, workerID string) (output *v1payload.StopW
 	}
 
 	return output, c.doRequest(http.MethodDelete, createPath(projectID, workersEndpoint, workerID), input, output)
+}
+
+// ListWorkers will return all tasks in a worker
+func (c *Client) ListWorkers(projectID string) (output *v1payload.ListWorkersOutput, err error) {
+	output = &v1payload.ListWorkersOutput{}
+	input := &v1payload.ListWorkersInput{
+		ProjectID: projectID,
+	}
+
+	return output, c.doRequest(http.MethodGet, createPath(projectID, workersEndpoint), input, output)
 }


### PR DESCRIPTION
This pull request introduces:

- [x] payloads for project placement
- [x] payloads for worker management
- [x] commands for `project place` and `project expel`
- [x] commands for `worker start <image>`, `worker stop <worker_id>` and `worker list`
- [ ] ~~Add environment variables for worker pods~~ (do in other PR)
- [ ] ~~Add worker JWT as a env variable~~ (do in other PR)