### PR TITLE
Remove quotes from output of datasetID

### DIFF
--- a/command/dataset_upload.go
+++ b/command/dataset_upload.go
@@ -93,7 +93,7 @@ func (cmd *Upload) DoRun(args []string) (err error) {
 		return HandleError(err)
 	}
 	<-progressBarDoneCh
-	tmpl := "Upload complete! ID of new dataset: '{{$.DatasetID}}'\n"
+	tmpl := "Upload complete! ID of new dataset: {{$.DatasetID}}\n"
 	jsonTmpl := "{\"dataset_id\":\"{{$.DatasetID}}}\"}"
 	cmd.outputter.Output(format.DecMap{
 		format.OutputTypePretty: format.NewTmplDecorator(dataset, tmpl),


### PR DESCRIPTION
This allows for for easier selection and copy/pasting of the dataset id. Besides, quotes seem not be used around other outputted ids.