### PR TITLE
Sort datasets and workload lists by CreatedAt when displaying them

### DIFF
--- a/command/dataset_list.go
+++ b/command/dataset_list.go
@@ -1,6 +1,8 @@
 package command
 
 import (
+	"sort"
+
 	"github.com/mitchellh/cli"
 	"github.com/nerdalize/nerd/command/format"
 	"github.com/pkg/errors"
@@ -46,6 +48,10 @@ func (cmd *DatasetList) DoRun(args []string) (err error) {
 	if err != nil {
 		return HandleError(err)
 	}
+
+	sort.Slice(datasets.Datasets, func (i int, j int) bool {
+		return datasets.Datasets[i].CreatedAt < datasets.Datasets[j].CreatedAt
+	})
 
 	header := "DATASET ID\tCREATED"
 	pretty := "{{range $i, $x := $.Datasets}}{{$x.DatasetID}}\t{{$x.CreatedAt | fmtUnixAgo }}\n{{end}}"

--- a/command/workload_list.go
+++ b/command/workload_list.go
@@ -1,6 +1,8 @@
 package command
 
 import (
+	"sort"
+
 	"github.com/mitchellh/cli"
 	"github.com/nerdalize/nerd/command/format"
 	"github.com/pkg/errors"
@@ -46,6 +48,10 @@ func (cmd *WorkloadList) DoRun(args []string) (err error) {
 	if err != nil {
 		return HandleError(err)
 	}
+
+	sort.Slice(out.Workloads, func (i int, j int) bool {
+		return out.Workloads[i].CreatedAt < out.Workloads[j].CreatedAt
+	})
 
 	header := "WORKLOAD ID\tIMAGE\tINPUT\tCREATED"
 	pretty := "{{range $i, $x := $.Workloads}}{{$x.WorkloadID}}\t{{$x.Image}}\t{{$x.InputDatasetID}}\t{{$x.CreatedAt | fmtUnixAgo }}\n{{end}}"


### PR DESCRIPTION
Not sure if you guys want this, but I'm running it locally and thought I'd at least see if you're interested. Because deleting datasets is impossible now, over time a users of nerdalize acquire many datasets. When listing datasets through `nerd dataset list`, these datasets are sorted alphabetically by their id, which makes it annoying to look up your latest dataset: 

```
DATASET ID             CREATED
002b53d2a66d867bfd39   22 hours ago
10ae4676e566b78ed181   1 week ago
16a8b1ae95d8ad6401b5   4 days ago
2099d906eecb09d8c705   2 weeks ago
2b132510d0ebe9d81d86   2 weeks ago
3956b8ae7a08070ba699   21 hours ago
474f33d367740dec8a92   1 week ago
52ca6562822f339d270a   21 hours ago
62bfd2d9fd4c7c0e508e   1 month ago
7411f097edd9a18deb85   4 days ago
8c2306f7af1bb5bf6e2f   2 weeks ago
a6f66206aef6415a39d1   1 month ago
ad4c8763890abaa1d833   2 weeks ago
b6073dbea6aac739c665   1 week ago
bf961405b88624dc7dd7   1 month ago
ca7a82708eaf30508915   1 month ago
cbcf47cefde806f2fc07   19 hours ago
e789d7e1528b4ea032c3   1 day ago
e826dce77e1253f05bc2   2 weeks ago
f4684fdeef9a2c58111e   2 weeks ago
```

Sorting them by dat makes it possible for me to easily see what was the newest dataset:
```
DATASET ID             CREATED
bf961405b88624dc7dd7   1 month ago
a6f66206aef6415a39d1   1 month ago
ca7a82708eaf30508915   1 month ago
62bfd2d9fd4c7c0e508e   1 month ago
2099d906eecb09d8c705   2 weeks ago
8c2306f7af1bb5bf6e2f   2 weeks ago
e826dce77e1253f05bc2   2 weeks ago
ad4c8763890abaa1d833   2 weeks ago
2b132510d0ebe9d81d86   2 weeks ago
f4684fdeef9a2c58111e   2 weeks ago
474f33d367740dec8a92   1 week ago
10ae4676e566b78ed181   1 week ago
b6073dbea6aac739c665   1 week ago
16a8b1ae95d8ad6401b5   4 days ago
7411f097edd9a18deb85   4 days ago
e789d7e1528b4ea032c3   1 day ago
002b53d2a66d867bfd39   22 hours ago
3956b8ae7a08070ba699   21 hours ago
52ca6562822f339d270a   21 hours ago
cbcf47cefde806f2fc07   19 hours ago
```

For good measure, I've added the same sorting to workloads, where a similar thing could happen. It might be a better idea to apply sorting server-side, but in absence of that, this works for now.

Cheers!
