### PR TITLE
Inform users about datasets usage (for/from which job a dataset is used)

### DIFF
--- a/cmd/dataset_list.go
+++ b/cmd/dataset_list.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"sort"
+	"strings"
 
 	humanize "github.com/dustin/go-humanize"
 	flags "github.com/jessevdk/go-flags"
@@ -49,13 +50,15 @@ func (cmd *DatasetList) Execute(args []string) (err error) {
 		return out.Items[i].Details.CreatedAt.After(out.Items[j].Details.CreatedAt)
 	})
 
-	hdr := []string{"DATASET", "CREATED AT", "SIZE"}
+	hdr := []string{"DATASET", "CREATED AT", "SIZE", "INPUT FOR", "OUTPUT FROM"}
 	rows := [][]string{}
 	for _, item := range out.Items {
 		rows = append(rows, []string{
 			item.Name,
 			humanize.Time(item.Details.CreatedAt),
 			humanize.Bytes(item.Details.Size),
+			strings.Join(item.Details.InputFor, ","),
+			strings.Join(item.Details.OutputFrom, ","),
 		})
 	}
 

--- a/cmd/dataset_list.go
+++ b/cmd/dataset_list.go
@@ -46,6 +46,11 @@ func (cmd *DatasetList) Execute(args []string) (err error) {
 		return renderServiceError(err, "failed to list datasets")
 	}
 
+	if len(out.Items) == 0 {
+		cmd.out.Infof("No resources found.")
+		return nil
+	}
+
 	sort.Slice(out.Items, func(i int, j int) bool {
 		return out.Items[i].Details.CreatedAt.After(out.Items[j].Details.CreatedAt)
 	})

--- a/cmd/job_list.go
+++ b/cmd/job_list.go
@@ -52,12 +52,14 @@ func (cmd *JobList) Execute(args []string) (err error) {
 	sort.Slice(out.Items, func(i int, j int) bool {
 		return out.Items[i].CreatedAt.After(out.Items[j].CreatedAt)
 	})
-	hdr := []string{"JOB", "IMAGE", "CREATED AT", "PHASE", "DETAILS"}
+	hdr := []string{"JOB", "IMAGE", "INPUT", "OUTPUT", "CREATED AT", "PHASE", "DETAILS"}
 	rows := [][]string{}
 	for _, item := range out.Items {
 		rows = append(rows, []string{
 			item.Name,
 			item.Image,
+			item.Input,
+			item.Output,
 			humanize.Time(item.CreatedAt),
 			renderItemPhase(item),
 			strings.Join(renderItemDetails(item), ","),

--- a/cmd/job_list.go
+++ b/cmd/job_list.go
@@ -47,6 +47,11 @@ func (cmd *JobList) Execute(args []string) (err error) {
 		return renderServiceError(err, "failed to list jobs")
 	}
 
+	if len(out.Items) == 0 {
+		cmd.out.Infof("No resources found.")
+		return nil
+	}
+
 	cmd.out.Infof("To see the logs of a job, use: `nerd job logs <JOB-NAME>`")
 
 	sort.Slice(out.Items, func(i int, j int) bool {

--- a/cmd/job_run.go
+++ b/cmd/job_run.go
@@ -203,8 +203,6 @@ func (cmd *JobRun) Execute(args []string) (err error) {
 		return renderServiceError(err, "failed to run job")
 	}
 
-	// @TODO update input dataset with job identifier
-	// @TODO update output dataset with job identifier
 	err = updateDataset(ctx, inputDataset, outputDataset, out.Name, kube)
 	cmd.out.Infof("Submitted job: '%s'", out.Name)
 	cmd.out.Infof("To see whats happening, use: 'nerd job list'")

--- a/crd/pkg/apis/stable.nerdalize.com/v1/types.go
+++ b/crd/pkg/apis/stable.nerdalize.com/v1/types.go
@@ -18,11 +18,11 @@ type Dataset struct {
 
 // DatasetSpec is the spec for a Dataset resource
 type DatasetSpec struct {
-	Key        string `json:"key"`
-	Bucket     string `json:"bucket"`
-	Size       uint64 `json:"size"`
-	InputFor   string `json:"input"`
-	OutputFrom string `json:"output"`
+	Key        string   `json:"key"`
+	Bucket     string   `json:"bucket"`
+	Size       uint64   `json:"size"`
+	InputFor   []string `json:"input"`
+	OutputFrom []string `json:"output"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/crd/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/crd/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -40,7 +40,15 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 
 	fakePtr := testing.Fake{}
 	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
-	fakePtr.AddWatchReactor("*", testing.DefaultWatchReactor(watch.NewFake(), nil))
+	fakePtr.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
 
 	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
 }

--- a/crd/pkg/client/clientset/versioned/fake/register.go
+++ b/crd/pkg/client/clientset/versioned/fake/register.go
@@ -48,5 +48,4 @@ func init() {
 // correctly.
 func AddToScheme(scheme *runtime.Scheme) {
 	nerdalizev1.AddToScheme(scheme)
-
 }

--- a/crd/pkg/client/clientset/versioned/scheme/register.go
+++ b/crd/pkg/client/clientset/versioned/scheme/register.go
@@ -48,5 +48,4 @@ func init() {
 // correctly.
 func AddToScheme(scheme *runtime.Scheme) {
 	nerdalizev1.AddToScheme(scheme)
-
 }

--- a/svc/kube_delete_dataset_test.go
+++ b/svc/kube_delete_dataset_test.go
@@ -20,7 +20,7 @@ func TestDeleteDataset(t *testing.T) {
 		Input    *svc.DeleteDatasetInput
 		Output   *svc.DeleteDatasetOutput
 		Listing  *svc.ListDatasetsOutput
-		IsOutput func(tb testing.TB, out *svc.DeleteDatasetOutput, list *svc.ListDatasetsOutput)
+		IsOutput func(tb testing.TB, out *svc.DeleteDatasetOutput, l *svc.ListDatasetsOutput)
 		IsErr    func(error) bool
 	}{
 		{

--- a/svc/kube_fetch_job_logs_test.go
+++ b/svc/kube_fetch_job_logs_test.go
@@ -23,6 +23,16 @@ func TestFetchJobLogs(t *testing.T) {
 		IsErr    func(error) bool
 	}{
 		{
+			Name:    "when a zero value input is provided it should return a validation error",
+			Timeout: time.Second * 5,
+			Jobs:    nil,
+			Input:   nil,
+			IsErr:   svc.IsValidationErr,
+			IsOutput: func(t testing.TB, out *svc.FetchJobLogsOutput) bool {
+				return true
+			},
+		},
+		{
 			Name:    "when job doesnt exist it should that there were no logs available",
 			Timeout: time.Second * 5,
 			Input:   &svc.FetchJobLogsInput{Name: "my-job"},

--- a/svc/kube_get_dataset.go
+++ b/svc/kube_get_dataset.go
@@ -19,8 +19,8 @@ type GetDatasetOutput struct {
 	Bucket     string
 	Key        string
 	Size       uint64
-	InputFor   string
-	OutputFrom string
+	InputFor   []string
+	OutputFrom []string
 }
 
 //GetDataset will create a dataset on kubernetes

--- a/svc/kube_get_dataset_test.go
+++ b/svc/kube_get_dataset_test.go
@@ -22,6 +22,16 @@ func TestGetDataset(t *testing.T) {
 		IsErr    func(error) bool
 	}{
 		{
+			Name:     "when a zero value input is provided it should return a validation error",
+			Timeout:  time.Second * 5,
+			Datasets: nil,
+			Input:    nil,
+			IsErr:    svc.IsValidationErr,
+			IsOutput: func(t testing.TB, out *svc.GetDatasetOutput) bool {
+				return true
+			},
+		},
+		{
 			Name:    "when dataset doesnt exist it should return an error",
 			Timeout: time.Second * 5,
 			Input:   &svc.GetDatasetInput{Name: "my-dataset"},

--- a/svc/kube_list_datasets.go
+++ b/svc/kube_list_datasets.go
@@ -63,28 +63,6 @@ func (k *Kube) ListDatasets(ctx context.Context, in *ListDatasetsInput) (out *Li
 		out.Items = append(out.Items, item)
 	}
 
-	// //Step 2: Get all pods under nerd-app=cli
-	// pods := &pods{}
-	// err = k.visor.ListResources(ctx, kubevisor.ResourceTypePods, pods, nil)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// //Step 3: Match pods to the datasets we got earlier
-	// for _, pod := range pods.Items {
-	// 	uid, ok := pod.Labels["controller-uid"]
-	// 	if !ok {
-	// 		continue //not part of a controller
-	// 	}
-
-	// 	datasetItem, ok := mapping[types.UID(uid)]
-	// 	if !ok {
-	// 		continue //not part of any dataset
-	// 	}
-	// 	datasetItem.Details.InputFor = append(datasetItem.Details.InputFor, pod.Labels["job"])
-
-	// }
-
 	return out, nil
 }
 

--- a/svc/kube_list_datasets.go
+++ b/svc/kube_list_datasets.go
@@ -12,8 +12,10 @@ import (
 
 //DatasetDetails tells us more about the dataset by looking at underlying resources
 type DatasetDetails struct {
-	CreatedAt time.Time
-	Size      uint64
+	CreatedAt  time.Time
+	Size       uint64
+	InputFor   []string
+	OutputFrom []string
 }
 
 //ListDatasetItem is a dataset listing item
@@ -50,8 +52,10 @@ func (k *Kube) ListDatasets(ctx context.Context, in *ListDatasetsInput) (out *Li
 		item := &ListDatasetItem{
 			Name: dataset.GetName(),
 			Details: DatasetDetails{
-				Size:      dataset.Spec.Size,
-				CreatedAt: dataset.CreationTimestamp.Local(),
+				Size:       dataset.Spec.Size,
+				InputFor:   dataset.Spec.InputFor,
+				OutputFrom: dataset.Spec.OutputFrom,
+				CreatedAt:  dataset.CreationTimestamp.Local(),
 			},
 		}
 

--- a/svc/kube_list_datasets_test.go
+++ b/svc/kube_list_datasets_test.go
@@ -21,6 +21,16 @@ func TestListDatasets(t *testing.T) {
 		IsErr    func(error) bool
 	}{
 		{
+			Name:     "when a zero value input is provided it should return a validation error",
+			Timeout:  time.Second * 5,
+			Datasets: nil,
+			Input:    nil,
+			IsErr:    svc.IsValidationErr,
+			IsOutput: func(t testing.TB, out *svc.ListDatasetsOutput) bool {
+				return true
+			},
+		},
+		{
 			Name:    "when no datasets have been uploaded the output should be empty",
 			Timeout: time.Second * 5,
 			Input:   &svc.ListDatasetsInput{},

--- a/svc/kube_list_jobs_test.go
+++ b/svc/kube_list_jobs_test.go
@@ -25,6 +25,16 @@ func TestListJobs(t *testing.T) {
 		IsErr    func(error) bool
 	}{
 		{
+			Name:    "when a zero value input is provided it should return a validation error",
+			Timeout: time.Second * 5,
+			Jobs:    nil,
+			Input:   nil,
+			IsErr:   svc.IsValidationErr,
+			IsOutput: func(t testing.TB, out *svc.ListJobsOutput) bool {
+				return true
+			},
+		},
+		{
 			Name:    "when no jobs have run the output should be empty",
 			Timeout: time.Second * 5,
 			Input:   &svc.ListJobsInput{},

--- a/svc/kube_update_dataset.go
+++ b/svc/kube_update_dataset.go
@@ -31,11 +31,14 @@ func (k *Kube) UpdateDataset(ctx context.Context, in *UpdateDatasetInput) (out *
 		return nil, err
 	}
 
-	if in.NewName != "" {
+	switch {
+	case in.NewName != "":
 		dataset.SetName(in.NewName)
+	case in.InputFor != "":
+		dataset.Spec.InputFor = append(dataset.Spec.InputFor, in.InputFor)
+	case in.OutputFrom != "":
+		dataset.Spec.OutputFrom = append(dataset.Spec.OutputFrom, in.OutputFrom)
 	}
-	dataset.Spec.InputFor = append(dataset.Spec.InputFor, in.InputFor)
-	dataset.Spec.OutputFrom = append(dataset.Spec.OutputFrom, in.OutputFrom)
 
 	err = k.visor.UpdateResource(ctx, kubevisor.ResourceTypeDatasets, dataset, in.Name)
 	if err != nil {

--- a/svc/kube_update_dataset.go
+++ b/svc/kube_update_dataset.go
@@ -34,10 +34,8 @@ func (k *Kube) UpdateDataset(ctx context.Context, in *UpdateDatasetInput) (out *
 	if in.NewName != "" {
 		dataset.SetName(in.NewName)
 	}
-	dataset.Spec = datasetsv1.DatasetSpec{
-		InputFor:   in.InputFor,
-		OutputFrom: in.OutputFrom,
-	}
+	dataset.Spec.InputFor = append(dataset.Spec.InputFor, in.InputFor)
+	dataset.Spec.OutputFrom = append(dataset.Spec.OutputFrom, in.OutputFrom)
 
 	err = k.visor.UpdateResource(ctx, kubevisor.ResourceTypeDatasets, dataset, in.Name)
 	if err != nil {

--- a/svc/kube_update_dataset.go
+++ b/svc/kube_update_dataset.go
@@ -31,12 +31,13 @@ func (k *Kube) UpdateDataset(ctx context.Context, in *UpdateDatasetInput) (out *
 		return nil, err
 	}
 
-	switch {
-	case in.NewName != "":
+	if in.NewName != "" {
 		dataset.SetName(in.NewName)
-	case in.InputFor != "":
+	}
+	if in.InputFor != "" {
 		dataset.Spec.InputFor = append(dataset.Spec.InputFor, in.InputFor)
-	case in.OutputFrom != "":
+	}
+	if in.OutputFrom != "" {
 		dataset.Spec.OutputFrom = append(dataset.Spec.OutputFrom, in.OutputFrom)
 	}
 

--- a/svc/kube_update_dataset_test.go
+++ b/svc/kube_update_dataset_test.go
@@ -2,6 +2,7 @@ package svc_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,10 +21,15 @@ func TestUpdateDataset(t *testing.T) {
 	out, err := kube.CreateDataset(ctx, &svc.CreateDatasetInput{Name: "my-dataset", Bucket: "bogus", Key: "my-key"})
 	ok(t, err)
 
-	_, err = kube.UpdateDataset(ctx, &svc.UpdateDatasetInput{Name: out.Name, InputFor: "j-123abc"})
+	_, err = kube.UpdateDataset(ctx, &svc.UpdateDatasetInput{
+		Name:       out.Name,
+		InputFor:   "j-123abc",
+		OutputFrom: "j-456def",
+	})
 	ok(t, err)
 
 	o, err := kube.GetDataset(ctx, &svc.GetDatasetInput{Name: out.Name})
 	ok(t, err)
-	assert(t, o.InputFor == "j-123abc", "expected dataset to be up to date")
+	assert(t, strings.Contains(strings.Join(o.InputFor, ""), "j-123abc"), "expected dataset to be up to date")
+	assert(t, strings.Contains(strings.Join(o.OutputFrom, ""), "j-456def"), "expected dataset to be up to date and to contain job info for output section")
 }


### PR DESCRIPTION
Closes #243, closes #244 

This pull request adds a new set of information:
- [x] while running `nerd dataset list`, we see for which job a dataset was used
![image](https://user-images.githubusercontent.com/7657393/35673177-0a839b72-0741-11e8-8977-ae5bf6e3ac5f.png)
- [x] while running `nerd job list`, we see which dataset was used or created by a job
![image](https://user-images.githubusercontent.com/7657393/35674255-5d8a61cc-0744-11e8-908a-85ace4220f1f.png)
