### PR TITLE
Fix various CLI problems including Windows fixes

### DIFF
--- a/cmd/flex/main.go
+++ b/cmd/flex/main.go
@@ -400,8 +400,8 @@ func (volp *DatasetVolumes) handleOutput(path, namespace, dataset string) error 
 
 	kube := svc.NewKube(di)
 	_, err = kube.UpdateDataset(context.TODO(), &svc.UpdateDatasetInput{
-		Name:       dataset,
-		Size:       &size,
+		Name: dataset,
+		Size: &size,
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to update size in dataset resource")

--- a/cmd/job_run.go
+++ b/cmd/job_run.go
@@ -35,6 +35,12 @@ func JobRunFactory(ui cli.Ui) cli.CommandFactory {
 	}
 }
 
+//isPathAbsUnix checks if a path is absolute on a Unix system.
+//Derived from https://github.com/golang/go/blob/1106512db54fc2736c7a9a67dd553fc9e1fca742/src/path/filepath/path_unix.go#L12
+func isPathAbsUnix(path string) bool {
+	return strings.HasPrefix(path, "/")
+}
+
 //Execute runs the command
 func (cmd *JobRun) Execute(args []string) (err error) {
 	if len(args) < 1 {
@@ -77,7 +83,7 @@ func (cmd *JobRun) Execute(args []string) (err error) {
 			return fmt.Errorf("invalid input specified, expected '<DIR|DATASET_ID>:<JOB_DIR>' format, got: %s", input)
 		}
 
-		if !filepath.IsAbs(parts[1]) {
+		if !isPathAbsUnix(parts[1]) {
 			return fmt.Errorf("the job directory for the input dataset must be provided as an absolute path")
 		}
 
@@ -134,7 +140,7 @@ func (cmd *JobRun) Execute(args []string) (err error) {
 			return fmt.Errorf("invalid output specified, expected '<JOB_DIR>:[DATASET_NAME]' format, got: %s", output)
 		}
 
-		if !filepath.IsAbs(parts[0]) {
+		if !isPathAbsUnix(parts[0]) {
 			return fmt.Errorf("the job directory for the output dataset must be provided as an absolute path")
 		}
 

--- a/cmd/job_run.go
+++ b/cmd/job_run.go
@@ -79,9 +79,15 @@ func (cmd *JobRun) Execute(args []string) (err error) {
 	vols := map[string]*svc.JobVolume{}
 	for _, input := range cmd.Inputs {
 		parts := strings.Split(input, ":")
-		if len(parts) != 2 {
+		if len(parts) < 1 {
 			return fmt.Errorf("invalid input specified, expected '<DIR|DATASET_ID>:<JOB_DIR>' format, got: %s", input)
 		}
+
+		//Handle Windows paths where DIR may contain colons
+		//e.g. C:/foo/bar:/input will be parsed into []string{"C", "/foo/bar", "/input"}
+		//and should be turned into []string{"C:/foo/bar", "/input"}
+		//We assume that POSIX paths will never have colons
+		parts = []string{strings.Join(parts[:len(parts)-1], ":"), parts[len(parts)-1]}
 
 		if !isPathAbsUnix(parts[1]) {
 			return fmt.Errorf("the job directory for the input dataset must be provided as an absolute path")

--- a/cmd/job_run.go
+++ b/cmd/job_run.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 
 	"github.com/jessevdk/go-flags"
-	"github.com/pkg/errors"
-	"github.com/mitchellh/go-homedir"
 	"github.com/mitchellh/cli"
+	"github.com/mitchellh/go-homedir"
+	"github.com/pkg/errors"
 
 	"github.com/nerdalize/nerd/pkg/transfer"
 	"github.com/nerdalize/nerd/svc"

--- a/cmd/job_run.go
+++ b/cmd/job_run.go
@@ -8,8 +8,9 @@ import (
 
 	"github.com/jessevdk/go-flags"
 	"github.com/pkg/errors"
-
+	"github.com/mitchellh/go-homedir"
 	"github.com/mitchellh/cli"
+
 	"github.com/nerdalize/nerd/pkg/transfer"
 	"github.com/nerdalize/nerd/svc"
 )
@@ -88,6 +89,12 @@ func (cmd *JobRun) Execute(args []string) (err error) {
 		//and should be turned into []string{"C:/foo/bar", "/input"}
 		//We assume that POSIX paths will never have colons
 		parts = []string{strings.Join(parts[:len(parts)-1], ":"), parts[len(parts)-1]}
+
+		//Expand tilde for homedir
+		parts[0], err = homedir.Expand(parts[0])
+		if err != nil {
+			return errors.Wrap(err, "failed to expand home directory in dataset input path")
+		}
 
 		if !isPathAbsUnix(parts[1]) {
 			return fmt.Errorf("the job directory for the input dataset must be provided as an absolute path")

--- a/cmd/job_run.go
+++ b/cmd/job_run.go
@@ -61,6 +61,13 @@ func ParseInputSpecification(input string) (parts []string, err error) {
 	//Normalize all slashes to native platform slashes (e.g. / to \ on Windows)
 	parts[0] = filepath.FromSlash(parts[0])
 
+	// Ensure that all parts are non-empty
+	if len(strings.TrimSpace(parts[0])) == 0 {
+		return nil, errors.New("input source is empty")
+	} else if len(strings.TrimSpace(parts[1])) == 0 {
+		return nil, errors.New("input mount path is empty")
+	}
+
 	return parts, nil
 }
 

--- a/cmd/job_run_test.go
+++ b/cmd/job_run_test.go
@@ -66,7 +66,7 @@ func TestParseInputSpecification(t *testing.T) {
 		if testCase.err && err == nil {
 			t.Errorf("expected error for input %s, but got no error and output %v", testCase.input, parts)
 		} else if !testCase.err && err != nil {
-			t.Errorf("expected no error for input %s, but got %s", err)
+			t.Errorf("expected no error for input %s, but got %s", testCase.input, err)
 		}
 
 		if !reflect.DeepEqual(parts, testCase.parts) {

--- a/cmd/job_run_test.go
+++ b/cmd/job_run_test.go
@@ -1,0 +1,77 @@
+package cmd_test
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/mitchellh/cli"
+
+	"github.com/nerdalize/nerd/cmd"
+)
+
+func TestJobExecute(t *testing.T) {
+	ui := &cli.BasicUi{
+		Reader:      os.Stdin,
+		Writer:      os.Stdout,
+		ErrorWriter: os.Stderr,
+	}
+
+	jobRun, err := cmd.JobRunFactory(ui)()
+	if err != nil {
+		t.Fatal("expected job run factory to return an instance, but got ", err)
+	}
+	command := jobRun.(*cmd.JobRun)
+
+	err = command.Execute([]string{})
+	if err == nil {
+		t.Error("expected job run without arguments to return error, but got ", err)
+	}
+}
+
+func TestParseInputSpecification(t *testing.T) {
+	var pathTests = []struct {
+		input string
+		parts []string
+		err   bool
+	}{
+		// Generic
+		{"somedataset:/input", []string{"somedataset", "/input"}, false},
+		{"some/relative/directory/:/input", []string{"some/relative/directory/", "/input"}, false},
+		{"./dot/relative/path:/input", []string{"./dot/relative/path", "/input"}, false},
+		{"./data:/~/valid/abs/path", []string{"./data", "/~/valid/abs/path"}, false},
+		{"C:/input", []string{"C", "/input"}, false}, // Can we detect this "mistake"?
+
+		// Failure cases
+		{"", nil, true},
+		{"nocolons", nil, true},
+		{"/too:/many:/colons:/here", nil, true},
+		{"./data:./relative/path", nil, true},
+		{"./data:~/home/dir", nil, true},
+		{"./data:", nil, true},
+		{":/input", nil, true},
+		{"./data:\\wrong\\separators", nil, true},
+
+		// Windows
+		{"C:/some/dir:/input", []string{"C:/some/dir", "/input"}, false},
+		{"//some/dir:/input", []string{"//some/dir", "/input"}, false},
+		{"C:\\some\\dir:/input", []string{"C:\\some\\dir", "/input"}, false},
+
+		// Linux
+		{"/some/abs/path:/input", []string{"/some/abs/path", "/input"}, false},
+	}
+
+	for _, testCase := range pathTests {
+		parts, err := cmd.ParseInputSpecification(testCase.input)
+
+		if testCase.err && err == nil {
+			t.Errorf("expected error for input %s, but got no error", testCase.input)
+		} else if !testCase.err && err != nil {
+			t.Errorf("expected no error for input %s, but got %s", err)
+		}
+
+		if !reflect.DeepEqual(parts, testCase.parts) {
+			t.Errorf("expected %s to be parsed into %v, but got %v", testCase.input, testCase.parts, parts)
+		}
+	}
+}

--- a/cmd/job_run_test.go
+++ b/cmd/job_run_test.go
@@ -46,11 +46,10 @@ func TestParseInputSpecification(t *testing.T) {
 		{"", nil, true},
 		{"nocolons", nil, true},
 		{"/too:/many:/colons:/here", nil, true},
-		{"./data:./relative/path", nil, true},
-		{"./data:~/home/dir", nil, true},
 		{"./data:", nil, true},
 		{":/input", nil, true},
-		{"./data:\\wrong\\separators", nil, true},
+		{" :/input", nil, true},
+		{"./data:    ", nil, true},
 
 		// Windows
 		{"C:/some/dir:/input", []string{"C:/some/dir", "/input"}, false},
@@ -65,7 +64,7 @@ func TestParseInputSpecification(t *testing.T) {
 		parts, err := cmd.ParseInputSpecification(testCase.input)
 
 		if testCase.err && err == nil {
-			t.Errorf("expected error for input %s, but got no error", testCase.input)
+			t.Errorf("expected error for input %s, but got no error and output %v", testCase.input, parts)
 		} else if !testCase.err && err != nil {
 			t.Errorf("expected no error for input %s, but got %s", err)
 		}

--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -104,14 +104,14 @@ func NewDeps(logs svc.Logger, kopts KubeOpts) (*Deps, error) {
 	}
 
 	val := validator.New()
-	val.RegisterValidation("is-abs-path", validateAbsPath)
+	val.RegisterValidation("is-abs-path", ValidateAbsPath)
 	d.val = val
 
 	return d, nil
 }
 
 //Derived from https://github.com/golang/go/blob/1106512db54fc2736c7a9a67dd553fc9e1fca742/src/path/filepath/path_unix.go#L12
-func validateAbsPath(fl validator.FieldLevel) bool {
+func ValidateAbsPath(fl validator.FieldLevel) bool {
 	return strings.HasPrefix(fl.Field().String(), "/")
 }
 

--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+	"fmt"
+	"strings"
 
 	"github.com/nerdalize/nerd/nerd"
 
@@ -102,8 +104,16 @@ func NewDeps(logs svc.Logger, kopts KubeOpts) (*Deps, error) {
 		return nil, nerd.ErrProjectIDNotSet
 	}
 
-	d.val = validator.New()
+	val := validator.New()
+	val.RegisterValidation("is-abs-path", validateAbsPath)
+	d.val = val
+
 	return d, nil
+}
+
+//Derived from https://github.com/golang/go/blob/1106512db54fc2736c7a9a67dd553fc9e1fca742/src/path/filepath/path_unix.go#L12
+func validateAbsPath(fl validator.FieldLevel) bool {
+	return strings.HasPrefix(fl.Field().String(), "/")
 }
 
 //Kube provides the kubernetes dependency

--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"os"
 	"path/filepath"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/nerdalize/nerd/nerd"
 

--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"time"
-	"fmt"
 	"strings"
 
 	"github.com/nerdalize/nerd/nerd"

--- a/make.sh
+++ b/make.sh
@@ -16,6 +16,7 @@ function print_help {
 function run_build { #compile versioned executable and place it in $GOPATH/bin
 	go build \
     -ldflags "-X main.version=$(cat VERSION) -X main.commit=$(git rev-parse --short HEAD )" \
+	-tags "forceposix" \
     -o $GOPATH/bin/nerd \
     main.go
 }
@@ -77,7 +78,7 @@ function run_test { #unit test project
 
 function run_release { #cross compile new release builds
 	mkdir -p bin
-	gox -ldflags "-X main.version=$(cat VERSION) -X main.commit=$(git rev-parse --short HEAD )" -osarch="linux/amd64 windows/amd64 darwin/amd64" -output=./bin/{{.OS}}_{{.Arch}}/nerd
+	gox -ldflags "-X main.version=$(cat VERSION) -X main.commit=$(git rev-parse --short HEAD )" -tags "forceposix" -osarch="linux/amd64 windows/amd64 darwin/amd64" -output=./bin/{{.OS}}_{{.Arch}}/nerd
 }
 
 function run_publish { #publish cross compiled binaries

--- a/make.sh
+++ b/make.sh
@@ -74,6 +74,9 @@ function run_test { #unit test project
 
 	echo "--> running service tests"
 	go test -cover -v ./svc/...
+
+    echo "--> running command tests"
+    go test -cover -v ./cmd/...
 }
 
 function run_release { #cross compile new release builds

--- a/svc/kube_run_job.go
+++ b/svc/kube_run_job.go
@@ -39,7 +39,7 @@ const (
 
 //JobVolume can be used in a job
 type JobVolume struct {
-	MountPath     string
+	MountPath     string `validate:"is-abs-path"`
 	InputDataset  string
 	OutputDataset string
 }

--- a/svc/kube_update_dataset_test.go
+++ b/svc/kube_update_dataset_test.go
@@ -38,7 +38,7 @@ func TestUpdateDataset(t *testing.T) {
 
 	//Check if the output remains the same when not specifying any changes
 	_, err = kube.UpdateDataset(ctx, &svc.UpdateDatasetInput{
-		Name:       out.Name,
+		Name: out.Name,
 	})
 	ok(t, err)
 

--- a/svc/svc.go
+++ b/svc/svc.go
@@ -10,6 +10,7 @@ import (
 //Validator describes the validation dependency we require
 type Validator interface {
 	StructCtx(ctx context.Context, s interface{}) (err error)
+	Struct(s interface{}) (err error)
 }
 
 //Logger describes the logging dependency the services require

--- a/svc/utils_test.go
+++ b/svc/utils_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-playground/validator"
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/nerdalize/nerd/cmd"
 	crd "github.com/nerdalize/nerd/crd/pkg/client/clientset/versioned"
 	"github.com/nerdalize/nerd/pkg/kubevisor"
 	"github.com/nerdalize/nerd/svc"
@@ -79,7 +80,9 @@ func testDI(tb testing.TB) (svc.DI, func()) {
 	ok(tb, err)
 	tdi.crd, err = crd.NewForConfig(kcfg)
 	ok(tb, err)
-	tdi.val = validator.New()
+	val := validator.New()
+	val.RegisterValidation("is-abs-path", cmd.ValidateAbsPath)
+	tdi.val = val
 
 	ns, err := tdi.kube.CoreV1().Namespaces().Create(&v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{GenerateName: testNamespaceName(tb)},


### PR DESCRIPTION
The commandline syntax for inputs uses the `<JOB_DIR>:[DATASET_NAME]` syntax, but Windows paths usually have a colon in them, like `C:\something`. This currently makes it nigh impossible to use `nerd` on Windows.

Issues:

- [x] It requires a different format with `/flags` instead of `--flags`, which is confusing
- [x] It fails to parse `--output /output` because it thinks `/output` is an option instead of an argument
- [x] It checks if the job path is absolute using Windows requirements, which means that it does not consider `/input` absolute, for example
- [x] It requires absolute paths, which is inconvenient if they are quite long (also affects Linux/OSX) (@advanderveer why was it designed this way?)
- [x] It does not support `:` in paths, which is required for drive letters on Windows
- [x] Fix optional `--input` and `--output` errors
- [x] Refactor checks in `job run` and implement unit tests

Format can be fixed by adding `forceposix` build tag for the `go-flags` package:

https://github.com/jessevdk/go-flags/blob/4cc2832a6e6d1d3b815e2b9d544b2a4dfb3ce8fa/optstyle_windows.go

Update: Closes #159 
Closes #283 