### PR TITLE
Resource requests for jobs

### DIFF
--- a/cmd/job_list.go
+++ b/cmd/job_list.go
@@ -57,7 +57,7 @@ func (cmd *JobList) Execute(args []string) (err error) {
 	sort.Slice(out.Items, func(i int, j int) bool {
 		return out.Items[i].CreatedAt.After(out.Items[j].CreatedAt)
 	})
-	hdr := []string{"JOB", "IMAGE", "INPUT", "OUTPUT", "CREATED AT", "PHASE", "DETAILS"}
+	hdr := []string{"JOB", "IMAGE", "INPUT", "OUTPUT", "MEMORY", "VCPU", "CREATED AT", "PHASE", "DETAILS"}
 	rows := [][]string{}
 	for _, item := range out.Items {
 		rows = append(rows, []string{
@@ -65,6 +65,8 @@ func (cmd *JobList) Execute(args []string) (err error) {
 			item.Image,
 			item.Input,
 			item.Output,
+			item.Memory,
+			item.VCPU,
 			humanize.Time(item.CreatedAt),
 			renderItemPhase(item),
 			strings.Join(renderItemDetails(item), ","),

--- a/cmd/job_run.go
+++ b/cmd/job_run.go
@@ -21,6 +21,8 @@ type JobRun struct {
 	TransferOpts
 	Name    string   `long:"name" short:"n" description:"assign a name to the job"`
 	Env     []string `long:"env" short:"e" description:"environment variables to use"`
+	Memory  string   `long:"memory" short:"m" description:"memory to use for this job. Units accepted: Ki, Mi, Gi, K, M, G" default:"3Gi"`
+	VPCU    string   `long:"vcpu" description:"number of vcpus to use for this job" default:"2"`
 	Inputs  []string `long:"input" description:"specify one or more inputs that will be downloaded for the job"`
 	Outputs []string `long:"output" description:"specify one or more output folders that will be uploaded as datasets after the job is finished"`
 
@@ -167,7 +169,6 @@ func (cmd *JobRun) Execute(args []string) (err error) {
 		}
 	}
 
-	// var outputDataset string
 	for _, output := range cmd.Outputs {
 		parts := strings.Split(output, ":")
 		if len(parts) < 1 || len(parts) > 2 {
@@ -211,10 +212,12 @@ func (cmd *JobRun) Execute(args []string) (err error) {
 
 	//continue with actuall creating the job
 	in := &svc.RunJobInput{
-		Image: args[0],
-		Name:  cmd.Name,
-		Env:   jenv,
-		Args:  jargs,
+		Image:  args[0],
+		Name:   cmd.Name,
+		Env:    jenv,
+		Args:   jargs,
+		Memory: cmd.Memory,
+		VCPU:   cmd.VPCU,
 	}
 
 	for _, vol := range vols {

--- a/crd/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/crd/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -40,7 +40,15 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 
 	fakePtr := testing.Fake{}
 	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
-	fakePtr.AddWatchReactor("*", testing.DefaultWatchReactor(watch.NewFake(), nil))
+	fakePtr.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
 
 	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
 }

--- a/crd/pkg/client/clientset/versioned/fake/register.go
+++ b/crd/pkg/client/clientset/versioned/fake/register.go
@@ -37,7 +37,7 @@ func init() {
 //
 //   import (
 //     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kuberentes/scheme"
+//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
 //     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
 //   )
 //
@@ -48,5 +48,4 @@ func init() {
 // correctly.
 func AddToScheme(scheme *runtime.Scheme) {
 	nerdalizev1.AddToScheme(scheme)
-
 }

--- a/crd/pkg/client/clientset/versioned/scheme/register.go
+++ b/crd/pkg/client/clientset/versioned/scheme/register.go
@@ -37,7 +37,7 @@ func init() {
 //
 //   import (
 //     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kuberentes/scheme"
+//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
 //     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
 //   )
 //
@@ -48,5 +48,4 @@ func init() {
 // correctly.
 func AddToScheme(scheme *runtime.Scheme) {
 	nerdalizev1.AddToScheme(scheme)
-
 }

--- a/svc/kube_list_jobs.go
+++ b/svc/kube_list_jobs.go
@@ -53,6 +53,8 @@ type ListJobItem struct {
 	Image       string
 	Input       string
 	Output      string
+	Memory      string
+	VCPU        string
 	CreatedAt   time.Time
 	DeletedAt   time.Time
 	ActiveAt    time.Time
@@ -139,6 +141,8 @@ func (k *Kube) ListJobs(ctx context.Context, in *ListJobsInput) (out *ListJobsOu
 				item.FailedAt = cond.LastTransitionTime.Local()
 			}
 		}
+		item.Memory = job.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()
+		item.VCPU = job.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()
 
 		mapping[job.UID] = item
 		out.Items = append(out.Items, item)

--- a/svc/kube_list_jobs_test.go
+++ b/svc/kube_list_jobs_test.go
@@ -89,6 +89,22 @@ func TestListJobs(t *testing.T) {
 			},
 		},
 		{
+			Name:    "when a job is started it should show its resource requests",
+			Timeout: time.Second * 5,
+			Jobs:    []*svc.RunJobInput{{Image: "hello-world", Name: "my-job", Memory: "200Mi", VCPU: "0.1"}},
+			Input:   &svc.ListJobsInput{},
+			IsErr:   isNilErr,
+			IsOutput: func(t testing.TB, out *svc.ListJobsOutput) bool {
+				assert(t, len(out.Items) == 1, "expected one job to be listed")
+				if out.Items[0].CompletedAt.IsZero() {
+					return false
+				}
+				assert(t, out.Items[0].Memory == "200Mi", "should have memory request details")
+				assert(t, out.Items[0].VCPU == "100m", "should contain details about vcpu requests")
+				return true
+			},
+		},
+		{
 			Name:    "when job is run with the wrong image it should show a waiting reason at some point",
 			Timeout: time.Minute,
 			Jobs:    []*svc.RunJobInput{{Image: "there-is-no-image-called-this", Name: "invalid-image-job"}},

--- a/svc/kube_run_job_test.go
+++ b/svc/kube_run_job_test.go
@@ -120,6 +120,21 @@ func TestRunJobTemplate(t *testing.T) {
 				return true
 			},
 		},
+		{
+			Name:    "when resources are requested they should be found in the job template",
+			Timeout: time.Second * 10,
+			Input:   &svc.RunJobInput{Image: "nginx", Name: "my-resources", Memory: "200Mi", VCPU: "0.1"},
+			IsOutput: func(t testing.TB, out *batchv1.Job) bool {
+				if len(out.Spec.Template.Spec.Containers) < 1 {
+					return false
+				}
+				assert(t, out.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String() == "100m", "cpu should be equal as requested value")
+				assert(t, out.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String() == "200Mi", "memory should be equal as requested value")
+				assert(t, out.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String() == "100m", "cpu should be equal as requested value")
+				assert(t, out.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String() == "200Mi", "memory should be equal as requested value")
+				return true
+			},
+		},
 	} {
 		t.Run(c.Name, func(t *testing.T) {
 			di, clean := testDI(t)


### PR DESCRIPTION
This pull request introduces two new options for the `nerd job run` command: `--memory` and `--vcpu`. It will let the users specify how much resources they want to spend on one job.

- [x] Closes #289
![image](https://user-images.githubusercontent.com/7657393/36482982-270b01ac-1715-11e8-9c09-5242634293e4.png)
- [x] update `nerd job list` to display resource requests 
![image](https://user-images.githubusercontent.com/7657393/36483004-3da4432e-1715-11e8-831e-ccf911155c78.png)
- [x] update tests for kube_job_run
- [x] update tests for kube_job_list
- [x] display error when resources are exhausted
- [x] set memory limit (no more than 64 gb of memory can be requested)
- [x] set vcpu limit (no more than 40 vcpus can be requested)
- [x] use Gb by default so the users don't have to precise the units

It's good to know that for the memory, lowercase units do not work: [https://github.com/kubernetes/kubernetes/issues/49442](https://github.com/kubernetes/kubernetes/issues/49442), and allowed units can be found [here](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory).
