### PR TITLE
Dataset handling enhancement

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -153,12 +153,14 @@ type progressBarReporter struct {
 
 func (r *progressBarReporter) HandledKey(key string) {}
 
-func (r *progressBarReporter) StartArchivingProgress(label string, total int64) io.Writer {
+func (r *progressBarReporter) StartArchivingProgress(label string, total int64) func(int64) {
 	r.arch = pb.New(int(total)).SetUnits(pb.U_BYTES_DEC)
 	r.arch.Prefix(fmt.Sprintf("Archiving (Step 1/2):")) //@TODO with debug flag show temp file
 	r.arch.Start()
 
-	return r.arch
+	return func(n int64) {
+		r.arch.Add64(n)
+	}
 }
 
 func (r *progressBarReporter) StartUploadProgress(label string, total int64, rr io.Reader) io.Reader {

--- a/cmd/dataset_upload.go
+++ b/cmd/dataset_upload.go
@@ -62,6 +62,10 @@ func (cmd *DatasetUpload) Execute(args []string) (err error) {
 
 	err = h.Push(ctx, args[0], &progressBarReporter{})
 	if err != nil {
+		e := mgr.Remove(ctx, h.Name())
+		if e != nil {
+			return errors.Wrapf(err, "failed to upload dataset: %v", e)
+		}
 		return errors.Wrap(err, "failed to upload dataset")
 	}
 

--- a/cmd/dataset_upload.go
+++ b/cmd/dataset_upload.go
@@ -64,7 +64,7 @@ func (cmd *DatasetUpload) Execute(args []string) (err error) {
 	if err != nil {
 		e := mgr.Remove(ctx, h.Name())
 		if e != nil {
-			return errors.Wrapf(err, "failed to upload dataset: %v", e)
+			return errors.Wrapf(err, "failed to remove dataset: %v", e)
 		}
 		return errors.Wrap(err, "failed to upload dataset")
 	}

--- a/crd/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/crd/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -40,15 +40,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 
 	fakePtr := testing.Fake{}
 	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
-	fakePtr.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
-		gvr := action.GetResource()
-		ns := action.GetNamespace()
-		watch, err := o.Watch(gvr, ns)
-		if err != nil {
-			return false, nil, err
-		}
-		return true, watch, nil
-	})
+	fakePtr.AddWatchReactor("*", testing.DefaultWatchReactor(watch.NewFake(), nil))
 
 	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
 }

--- a/crd/pkg/client/clientset/versioned/fake/register.go
+++ b/crd/pkg/client/clientset/versioned/fake/register.go
@@ -37,7 +37,7 @@ func init() {
 //
 //   import (
 //     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//     clientsetscheme "k8s.io/client-go/kuberentes/scheme"
 //     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
 //   )
 //
@@ -48,4 +48,5 @@ func init() {
 // correctly.
 func AddToScheme(scheme *runtime.Scheme) {
 	nerdalizev1.AddToScheme(scheme)
+
 }

--- a/crd/pkg/client/clientset/versioned/scheme/register.go
+++ b/crd/pkg/client/clientset/versioned/scheme/register.go
@@ -37,7 +37,7 @@ func init() {
 //
 //   import (
 //     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//     clientsetscheme "k8s.io/client-go/kuberentes/scheme"
 //     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
 //   )
 //
@@ -48,4 +48,5 @@ func init() {
 // correctly.
 func AddToScheme(scheme *runtime.Scheme) {
 	nerdalizev1.AddToScheme(scheme)
+
 }

--- a/pkg/transfer/archiver/types.go
+++ b/pkg/transfer/archiver/types.go
@@ -4,7 +4,7 @@ import "io"
 
 //Reporter describes how an archiver reports
 type Reporter interface {
-	StartArchivingProgress(label string, total int64) io.Writer
+	StartArchivingProgress(label string, total int64) func(int64)
 	StopArchivingProgress()
 	StartUnarchivingProgress(label string, total int64, rr io.Reader) io.Reader
 	StopUnarchivingProgress()

--- a/pkg/transfer/types.go
+++ b/pkg/transfer/types.go
@@ -33,8 +33,8 @@ type DiscardReporter struct{}
 func (r *DiscardReporter) HandledKey(key string) {}
 
 //StartArchivingProgress is called when archiving has started and total size is known
-func (r *DiscardReporter) StartArchivingProgress(label string, total int64) io.Writer {
-	return ioutil.Discard
+func (r *DiscardReporter) StartArchivingProgress(label string, total int64) func(int64) {
+	return func(int64) {}
 }
 
 //StartUploadProgress is called when upload has started while total size is known


### PR DESCRIPTION
This pull request fixes #263 (partly) thanks to @advanderveer 's help. 
It also remove datasets that were created by the `nerd job run` command if this command fails (fixes #263). Same, when `nerd dataset upload` fails to send data to S3, it will delete the dataset from k8s (fixes #302).