### PR TITLE
Update directory tree for dataset download

### DIFF
--- a/cmd/dataset_download.go
+++ b/cmd/dataset_download.go
@@ -113,6 +113,10 @@ func (cmd *DatasetDownload) Execute(args []string) (err error) {
 	}
 	datasets := extractDatasets(ds.Items, cmd.Input, cmd.Output)
 	for _, dataset := range datasets {
+		dir := outputDir
+		if len(datasets) > 1 {
+			dir = filepath.Join(outputDir, dataset.Name)
+		}
 		var h transfer.Handle
 		if h, err = mgr.Open(
 			ctx,
@@ -123,12 +127,16 @@ func (cmd *DatasetDownload) Execute(args []string) (err error) {
 
 		defer h.Close()
 
-		err = h.Pull(ctx, filepath.Join(outputDir, dataset.Name), &progressBarReporter{})
+		err = h.Pull(ctx, dir, &progressBarReporter{})
 		if err != nil {
 			return errors.Wrap(err, "failed to download dataset")
 		}
 	}
-	cmd.out.Infof("Downloaded %d datasets in %s", len(datasets), outputDir)
+	if len(datasets) > 1 {
+		cmd.out.Infof("Downloaded %d datasets in %s", len(datasets), outputDir)
+	} else {
+		cmd.out.Infof("Downloaded %d dataset in %s", len(datasets), outputDir)
+	}
 	return nil
 }
 


### PR DESCRIPTION
This pull request updates the way we handle directories for `nerd dataset download` when the options `--input-of` or `--output-of` are used. Before, one subdirectory was created for each dataset even when there was only one dataset which was quite confusing. 

![image](https://user-images.githubusercontent.com/7657393/36780081-3a0e9252-1c72-11e8-8de0-69a0eb1b5446.png)
