### PR TITLE
Create advanced and global options

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -35,7 +35,12 @@ var (
 )
 
 type command struct {
-	globalOpts struct{}
+	globalOpts struct {
+		KubeOpts
+	}
+	//advandedOpts leaves us the possibility to provide different types of options.
+	//For now, we use it for the TransferOpts in `dataset upload` and `job run`
+	advancedOpts interface{}
 
 	name       string
 	flagParser *flags.Parser
@@ -45,7 +50,7 @@ type command struct {
 	out        *Output
 }
 
-func createCommand(ui cli.Ui, runFunc func([]string) error, helpFunc func() string, usageFunc func() string, fgroup interface{}, opts flags.Options, name string) *command {
+func createCommand(ui cli.Ui, runFunc func([]string) error, helpFunc func() string, usageFunc func() string, fgroup, adv interface{}, opts flags.Options, name string) *command {
 	c := &command{
 		flagParser: flags.NewNamedParser(usageFunc(), opts),
 		runFunc:    runFunc,
@@ -58,6 +63,14 @@ func createCommand(ui cli.Ui, runFunc func([]string) error, helpFunc func() stri
 	_, err := c.flagParser.AddGroup("Options", "Options", fgroup)
 	if err != nil {
 		panic("failed to add option group: " + err.Error())
+	}
+
+	if adv != nil {
+		_, err = c.flagParser.AddGroup("Advanced Options", "Advanced Options", adv)
+		if err != nil {
+			panic("failed to add option group: " + err.Error())
+		}
+		c.advancedOpts = adv
 	}
 
 	_, err = c.flagParser.AddGroup("Global Options", "Global Options", &c.globalOpts)

--- a/cmd/dataset.go
+++ b/cmd/dataset.go
@@ -13,7 +13,7 @@ type Dataset struct {
 //DatasetFactory creates the command
 func DatasetFactory(ui cli.Ui) cli.CommandFactory {
 	cmd := &Dataset{}
-	cmd.command = createCommand(ui, cmd.Execute, cmd.Description, cmd.Usage, cmd, flags.None, "nerd dataset")
+	cmd.command = createCommand(ui, cmd.Execute, cmd.Description, cmd.Usage, cmd, nil, flags.None, "nerd dataset")
 
 	return func() (cli.Command, error) {
 		return cmd, nil

--- a/cmd/dataset_delete.go
+++ b/cmd/dataset_delete.go
@@ -12,7 +12,6 @@ import (
 
 //DatasetDelete command
 type DatasetDelete struct {
-	KubeOpts
 	All bool `long:"all" short:"a" description:"delete all your datasets in one command"`
 
 	*command
@@ -21,7 +20,7 @@ type DatasetDelete struct {
 //DatasetDeleteFactory creates the command
 func DatasetDeleteFactory(ui cli.Ui) cli.CommandFactory {
 	cmd := &DatasetDelete{}
-	cmd.command = createCommand(ui, cmd.Execute, cmd.Description, cmd.Usage, cmd, flags.None, "nerd dataset delete")
+	cmd.command = createCommand(ui, cmd.Execute, cmd.Description, cmd.Usage, cmd, nil, flags.None, "nerd dataset delete")
 	return func() (cli.Command, error) {
 		return cmd, nil
 	}
@@ -36,14 +35,14 @@ func (cmd *DatasetDelete) Execute(args []string) (err error) {
 		return errShowUsage(fmt.Sprintf(MessageNotEnoughArguments, 1, ""))
 	}
 
-	kopts := cmd.KubeOpts
+	kopts := cmd.globalOpts.KubeOpts
 	deps, err := NewDeps(cmd.Logger(), kopts)
 	if err != nil {
 		return renderConfigError(err, "failed to configure")
 	}
 
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, cmd.Timeout)
+	ctx, cancel := context.WithTimeout(ctx, kopts.Timeout)
 	defer cancel()
 
 	kube := svc.NewKube(deps)
@@ -63,14 +62,14 @@ func (cmd *DatasetDelete) Execute(args []string) (err error) {
 }
 
 func (cmd *DatasetDelete) deleteAll() error {
-	kopts := cmd.KubeOpts
+	kopts := cmd.globalOpts.KubeOpts
 	deps, err := NewDeps(cmd.Logger(), kopts)
 	if err != nil {
 		return renderConfigError(err, "failed to configure")
 	}
 
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, cmd.Timeout)
+	ctx, cancel := context.WithTimeout(ctx, kopts.Timeout)
 	defer cancel()
 
 	s, err := cmd.out.Ask("Are you sure you want to delete all your datasets? (y/N)")

--- a/cmd/dataset_download.go
+++ b/cmd/dataset_download.go
@@ -21,8 +21,6 @@ const (
 
 //DatasetDownload command
 type DatasetDownload struct {
-	KubeOpts
-
 	Input  string `long:"input-of" description:"specify a job name where the datasets were used as its input. Dataset name is no longer mandatory."`
 	Output string `long:"output-of" description:"specify a job name where the datasets were used as its output. Dataset name is no longer mandatory."`
 
@@ -32,7 +30,7 @@ type DatasetDownload struct {
 //DatasetDownloadFactory creates the command
 func DatasetDownloadFactory(ui cli.Ui) cli.CommandFactory {
 	cmd := &DatasetDownload{}
-	cmd.command = createCommand(ui, cmd.Execute, cmd.Description, cmd.Usage, cmd, flags.None, "nerd dataset download")
+	cmd.command = createCommand(ui, cmd.Execute, cmd.Description, cmd.Usage, cmd, nil, flags.None, "nerd dataset download")
 	return func() (cli.Command, error) {
 		return cmd, nil
 	}
@@ -70,7 +68,7 @@ func (cmd *DatasetDownload) Execute(args []string) (err error) {
 		return renderServiceError(err, "failed to turn local path into absolute path")
 	}
 
-	deps, err := NewDeps(cmd.Logger(), cmd.KubeOpts)
+	deps, err := NewDeps(cmd.Logger(), cmd.globalOpts.KubeOpts)
 	if err != nil {
 		return renderConfigError(err, "failed to configure")
 	}

--- a/cmd/dataset_list.go
+++ b/cmd/dataset_list.go
@@ -13,15 +13,13 @@ import (
 
 //DatasetList command
 type DatasetList struct {
-	KubeOpts
-
 	*command
 }
 
 //DatasetListFactory creates the command
 func DatasetListFactory(ui cli.Ui) cli.CommandFactory {
 	cmd := &DatasetList{}
-	cmd.command = createCommand(ui, cmd.Execute, cmd.Description, cmd.Usage, cmd, flags.None, "nerd dataset list")
+	cmd.command = createCommand(ui, cmd.Execute, cmd.Description, cmd.Usage, cmd, nil, flags.None, "nerd dataset list")
 	return func() (cli.Command, error) {
 		return cmd, nil
 	}
@@ -32,14 +30,14 @@ func (cmd *DatasetList) Execute(args []string) (err error) {
 	if len(args) > 0 {
 		return errShowUsage(MessageNoArgumentRequired)
 	}
-	kopts := cmd.KubeOpts
+	kopts := cmd.globalOpts.KubeOpts
 	deps, err := NewDeps(cmd.Logger(), kopts)
 	if err != nil {
 		return renderConfigError(err, "failed to configure")
 	}
 
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, cmd.Timeout)
+	ctx, cancel := context.WithTimeout(ctx, kopts.Timeout)
 	defer cancel()
 
 	in := &svc.ListDatasetsInput{}

--- a/cmd/job.go
+++ b/cmd/job.go
@@ -13,7 +13,7 @@ type Job struct {
 //JobFactory creates the command
 func JobFactory(ui cli.Ui) cli.CommandFactory {
 	cmd := &Job{}
-	cmd.command = createCommand(ui, cmd.Execute, cmd.Description, cmd.Usage, cmd, flags.None, "nerd job")
+	cmd.command = createCommand(ui, cmd.Execute, cmd.Description, cmd.Usage, cmd, nil, flags.None, "nerd job")
 
 	return func() (cli.Command, error) {
 		return cmd, nil

--- a/cmd/job_delete.go
+++ b/cmd/job_delete.go
@@ -12,7 +12,6 @@ import (
 
 //JobDelete command
 type JobDelete struct {
-	KubeOpts
 	All bool `long:"all" short:"a" description:"delete all your jobs in one command"`
 
 	*command
@@ -21,7 +20,7 @@ type JobDelete struct {
 //JobDeleteFactory creates the command
 func JobDeleteFactory(ui cli.Ui) cli.CommandFactory {
 	cmd := &JobDelete{}
-	cmd.command = createCommand(ui, cmd.Execute, cmd.Description, cmd.Usage, cmd, flags.None, "nerd job delete")
+	cmd.command = createCommand(ui, cmd.Execute, cmd.Description, cmd.Usage, cmd, nil, flags.None, "nerd job delete")
 	return func() (cli.Command, error) {
 		return cmd, nil
 	}
@@ -36,14 +35,14 @@ func (cmd *JobDelete) Execute(args []string) (err error) {
 		return errShowUsage(fmt.Sprintf(MessageNotEnoughArguments, 1, ""))
 	}
 
-	kopts := cmd.KubeOpts
+	kopts := cmd.globalOpts.KubeOpts
 	deps, err := NewDeps(cmd.Logger(), kopts)
 	if err != nil {
 		return renderConfigError(err, "failed to configure")
 	}
 
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, cmd.Timeout)
+	ctx, cancel := context.WithTimeout(ctx, kopts.Timeout)
 	defer cancel()
 
 	kube := svc.NewKube(deps)
@@ -63,14 +62,14 @@ func (cmd *JobDelete) Execute(args []string) (err error) {
 	return nil
 }
 func (cmd *JobDelete) deleteAll() error {
-	kopts := cmd.KubeOpts
+	kopts := cmd.globalOpts.KubeOpts
 	deps, err := NewDeps(cmd.Logger(), kopts)
 	if err != nil {
 		return renderConfigError(err, "failed to configure")
 	}
 
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, cmd.Timeout)
+	ctx, cancel := context.WithTimeout(ctx, kopts.Timeout)
 	defer cancel()
 
 	s, err := cmd.out.Ask("Are you sure you want to delete all your jobs? (y/N)")

--- a/cmd/job_list.go
+++ b/cmd/job_list.go
@@ -14,15 +14,13 @@ import (
 
 //JobList command
 type JobList struct {
-	KubeOpts
-
 	*command
 }
 
 //JobListFactory creates the command
 func JobListFactory(ui cli.Ui) cli.CommandFactory {
 	cmd := &JobList{}
-	cmd.command = createCommand(ui, cmd.Execute, cmd.Description, cmd.Usage, cmd, flags.None, "nerd job list")
+	cmd.command = createCommand(ui, cmd.Execute, cmd.Description, cmd.Usage, cmd, nil, flags.None, "nerd job list")
 	return func() (cli.Command, error) {
 		return cmd, nil
 	}
@@ -33,14 +31,14 @@ func (cmd *JobList) Execute(args []string) (err error) {
 	if len(args) > 0 {
 		return errShowUsage(MessageNoArgumentRequired)
 	}
-	kopts := cmd.KubeOpts
+	kopts := cmd.globalOpts.KubeOpts
 	deps, err := NewDeps(cmd.Logger(), kopts)
 	if err != nil {
 		return renderConfigError(err, "failed to configure")
 	}
 
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, cmd.Timeout)
+	ctx, cancel := context.WithTimeout(ctx, kopts.Timeout)
 	defer cancel()
 
 	kube := svc.NewKube(deps)

--- a/cmd/job_logs.go
+++ b/cmd/job_logs.go
@@ -14,7 +14,6 @@ import (
 
 //JobLogs command
 type JobLogs struct {
-	KubeOpts
 	Tail int64 `long:"tail" short:"t" description:"only return the oldest N lines of the process logs"`
 
 	*command
@@ -23,7 +22,7 @@ type JobLogs struct {
 //JobLogsFactory creates the command
 func JobLogsFactory(ui cli.Ui) cli.CommandFactory {
 	cmd := &JobLogs{}
-	cmd.command = createCommand(ui, cmd.Execute, cmd.Description, cmd.Usage, cmd, flags.None, "nerd job logs")
+	cmd.command = createCommand(ui, cmd.Execute, cmd.Description, cmd.Usage, cmd, nil, flags.None, "nerd job logs")
 	return func() (cli.Command, error) {
 		return cmd, nil
 	}
@@ -37,14 +36,14 @@ func (cmd *JobLogs) Execute(args []string) (err error) {
 		return errShowUsage(fmt.Sprintf(MessageTooManyArguments, 1, ""))
 	}
 
-	kopts := cmd.KubeOpts
+	kopts := cmd.globalOpts.KubeOpts
 	deps, err := NewDeps(cmd.Logger(), kopts)
 	if err != nil {
 		return renderConfigError(err, "failed to configure")
 	}
 
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, cmd.Timeout)
+	ctx, cancel := context.WithTimeout(ctx, kopts.Timeout)
 	defer cancel()
 
 	in := &svc.FetchJobLogsInput{


### PR DESCRIPTION
Closes #354 

`--kube-config` and `--timeout` are now part of the global options. And when we create a command, we can now provide some additional options that will appear under the `Advanced options` section 