### PR TITLE
Make it possible to configure private S3 buckets

### DIFF
--- a/cmd/dataset_upload.go
+++ b/cmd/dataset_upload.go
@@ -51,7 +51,7 @@ func (cmd *DatasetUpload) Execute(args []string) (err error) {
 		return renderServiceError(err, "failed to expand home directory in dataset local path")
 	}
 
-	dir, err = filepath.Abs(args[0])
+	dir, err = filepath.Abs(dir)
 	if err != nil {
 		return renderServiceError(err, "failed to turn local path into absolute path")
 	}
@@ -72,6 +72,7 @@ func (cmd *DatasetUpload) Execute(args []string) (err error) {
 	if !ok {
 		return renderConfigError(fmt.Errorf("unable to use transfer options"), "failed to configure")
 	}
+
 	mgr, sto, sta, err := t.TransferManager(kube)
 	if err != nil {
 		return errors.Wrap(err, "failed to setup transfer manager")

--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -20,11 +20,12 @@ import (
 
 //TransferOpts hold CLI options for configuring data transfer
 type TransferOpts struct {
-	AWSS3Bucket        string `long:"aws-s3-bucket" description:"AWS S3 Bucket name that will be used for dataset storage" default:"nlz-datasets-dev"`
-	AWSRegion          string `long:"aws-region" description:"AWS region used for dataset storage"`
-	AWSAccessKeyID     string `long:"aws-access-key-id" description:"AWS access key used for auth with the storage backend"`
-	AWSSecretAccessKey string `long:"aws-secret-access-key" description:"AWS secret key for auth with the storage backend"`
-	AWSSessionToken    string `long:"aws-session-token" description:"AWS temporary auth token for the storage backend"`
+	S3Bucket       string `long:"s3-bucket" description:"S3 Bucket name that will be used for dataset storage" default:"nlz-datasets-dev"`
+	AWSRegion      string `long:"aws-region" description:"AWS region used for dataset storage"`
+	S3AccessKey    string `long:"s3-access-key" description:"access key used for auth with the storage backend"`
+	S3SecretKey    string `long:"s3-secret-key" description:"secret key for auth with the storage backend"`
+	S3SessionToken string `long:"s3-session-token" description:"temporary auth token for the storage backend"`
+	S3Prefix       string `long:"s3-prefix" description:"store this dataset under a specific prefix"`
 }
 
 //TransferManager creates a transfermanager using the command line options
@@ -36,8 +37,13 @@ func (opts TransferOpts) TransferManager(kube *svc.Kube) (mgr transfer.Manager, 
 	}
 
 	sto = &transferstore.StoreOptions{
-		Type:          transferstore.StoreTypeS3,
-		S3StoreBucket: opts.AWSS3Bucket,
+		Type:             transferstore.StoreTypeS3,
+		S3StoreBucket:    opts.S3Bucket,
+		S3StoreAWSRegion: opts.AWSRegion,
+		S3StoreAccessKey: opts.S3AccessKey,
+		S3StoreSecretKey: opts.S3SecretKey,
+		S3SessionToken:   opts.S3SessionToken,
+		S3StorePrefix:    opts.S3Prefix,
 	}
 	sta = &transferarchiver.ArchiverOptions{
 		Type: transferarchiver.ArchiverTypeTar,

--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -37,7 +37,7 @@ func (opts TransferOpts) TransferManager(kube *svc.Kube) (mgr transfer.Manager, 
 
 	sto = &transferstore.StoreOptions{
 		Type:          transferstore.StoreTypeS3,
-		S3StoreBucket: "nlz-datasets-dev",
+		S3StoreBucket: opts.AWSS3Bucket,
 	}
 	sta = &transferarchiver.ArchiverOptions{
 		Type: transferarchiver.ArchiverTypeTar,

--- a/spec.json
+++ b/spec.json
@@ -162,8 +162,8 @@
 			"options": {
 				"Advanced Options": [
 					{
-						"long_name": "aws-s3-bucket",
-						"description": "AWS S3 Bucket name that will be used for dataset storage",
+						"long_name": "s3-bucket",
+						"description": "S3 Bucket name that will be used for dataset storage",
 						"default_value": [
 							"nlz-datasets-dev"
 						],
@@ -176,20 +176,26 @@
 						"choices": null
 					},
 					{
-						"long_name": "aws-access-key-id",
-						"description": "AWS access key used for auth with the storage backend",
+						"long_name": "s3-access-key",
+						"description": "access key used for auth with the storage backend",
 						"default_value": null,
 						"choices": null
 					},
 					{
-						"long_name": "aws-secret-access-key",
-						"description": "AWS secret key for auth with the storage backend",
+						"long_name": "s3-secret-key",
+						"description": "secret key for auth with the storage backend",
 						"default_value": null,
 						"choices": null
 					},
 					{
-						"long_name": "aws-session-token",
-						"description": "AWS temporary auth token for the storage backend",
+						"long_name": "s3-session-token",
+						"description": "temporary auth token for the storage backend",
+						"default_value": null,
+						"choices": null
+					},
+					{
+						"long_name": "s3-prefix",
+						"description": "store this dataset under a specific prefix",
 						"default_value": null,
 						"choices": null
 					}
@@ -340,8 +346,8 @@
 			"options": {
 				"Advanced Options": [
 					{
-						"long_name": "aws-s3-bucket",
-						"description": "AWS S3 Bucket name that will be used for dataset storage",
+						"long_name": "s3-bucket",
+						"description": "S3 Bucket name that will be used for dataset storage",
 						"default_value": [
 							"nlz-datasets-dev"
 						],
@@ -354,20 +360,26 @@
 						"choices": null
 					},
 					{
-						"long_name": "aws-access-key-id",
-						"description": "AWS access key used for auth with the storage backend",
+						"long_name": "s3-access-key",
+						"description": "access key used for auth with the storage backend",
 						"default_value": null,
 						"choices": null
 					},
 					{
-						"long_name": "aws-secret-access-key",
-						"description": "AWS secret key for auth with the storage backend",
+						"long_name": "s3-secret-key",
+						"description": "secret key for auth with the storage backend",
 						"default_value": null,
 						"choices": null
 					},
 					{
-						"long_name": "aws-session-token",
-						"description": "AWS temporary auth token for the storage backend",
+						"long_name": "s3-session-token",
+						"description": "temporary auth token for the storage backend",
+						"default_value": null,
+						"choices": null
+					},
+					{
+						"long_name": "s3-prefix",
+						"description": "store this dataset under a specific prefix",
 						"default_value": null,
 						"choices": null
 					}


### PR DESCRIPTION
This pull requets adds the ability to configure private s3 buckets whenever a dataset is uploaded from Nerd.

- [x] Use cli options in upload command 
- [x] make sure these options are stored in pod configurations
- [ ] realise that s3 secrets are store inside the pod config and are not hidden whatsoever
- [x] make sure the flex volume uses these credentials as well
- [x] use multipart uploads/downloads if credentials are provided