### PR TITLE
Update SizeLimit option for archiver

### DIFF
--- a/examples/quota/q1.yml
+++ b/examples/quota/q1.yml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: compute-resources
+  labels:
+    flex-volume-size: "10000000000"
 spec:
   hard:
     requests.cpu: "1"

--- a/pkg/transfer/archiver/opts.go
+++ b/pkg/transfer/archiver/opts.go
@@ -13,4 +13,6 @@ type ArchiverOptions struct {
 	Type ArchiverType `json:"type"`
 
 	TarArchiverKeyPrefix string `json:"keyPrefix"`
+
+	SizeLimit int64 `json:"sizeLimit"`
 }

--- a/pkg/transfer/archiver/tar_archiver.go
+++ b/pkg/transfer/archiver/tar_archiver.go
@@ -11,6 +11,8 @@ import (
 
 	slashpath "path"
 
+	humanize "github.com/dustin/go-humanize"
+
 	"github.com/pkg/errors"
 )
 
@@ -30,8 +32,8 @@ var (
 	//ErrEmptyDirectory is returned when the archiver expected the directory to not be empty
 	ErrEmptyDirectory = errors.New("directory is empty")
 
-	//ErrDatasetTooLarge is returned when the dataset size is above 1Gb
-	ErrDatasetTooLarge = errors.New("dataset is too big, limit is 1Gb")
+	//ErrDatasetTooLarge is returned when the dataset size is above the sizelimit set in the dataset.
+	ErrDatasetTooLarge = "dataset is too big, limit is %s"
 
 	//SizeLimit is the maximum size allowed
 	//@TODO: Should be based on customer details?
@@ -162,7 +164,7 @@ func (a *TarArchiver) Archive(ctx context.Context, path string, rep Reporter, fn
 	}
 
 	if totalToTar > a.sizeLimit {
-		return ErrDatasetTooLarge
+		return errors.Errorf(ErrDatasetTooLarge, humanize.Bytes(uint64(a.sizeLimit)))
 	}
 
 	tmpf, clean, err := a.tempFile()

--- a/pkg/transfer/archiver/tar_archiver.go
+++ b/pkg/transfer/archiver/tar_archiver.go
@@ -41,14 +41,19 @@ var (
 //TarArchiver will archive a directory into a single tar file
 type TarArchiver struct {
 	keyPrefix string
+	sizeLimit int64
 }
 
 //NewTarArchiver will setup the tar archiver
 func NewTarArchiver(opts ArchiverOptions) (a *TarArchiver, err error) {
-	a = &TarArchiver{keyPrefix: opts.TarArchiverKeyPrefix}
+	a = &TarArchiver{keyPrefix: opts.TarArchiverKeyPrefix, sizeLimit: opts.SizeLimit}
 
 	if a.keyPrefix != "" && !strings.HasSuffix(a.keyPrefix, "/") {
 		return nil, errors.Errorf("archiver key prefix must end with a forward slash")
+	}
+
+	if a.sizeLimit <= 0 {
+		a.sizeLimit = SizeLimit
 	}
 
 	return a, nil
@@ -156,7 +161,7 @@ func (a *TarArchiver) Archive(ctx context.Context, path string, rep Reporter, fn
 		return errors.Wrap(err, "failed to index filesystem")
 	}
 
-	if totalToTar > SizeLimit {
+	if totalToTar > a.sizeLimit {
 		return ErrDatasetTooLarge
 	}
 


### PR DESCRIPTION
This pull request allows users to upload more than 1Gb as their output dataset.

The flexvolume should be rebuilt and redeployed for this pull request to be properly tested.
After this pull request is merged, a new flex volume daemonset should be deployed.