### PR TITLE
Fix set-default command and remove useless populator client

### DIFF
--- a/cmd/cluster_list.go
+++ b/cmd/cluster_list.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strconv"
 
 	"github.com/dustin/go-humanize"
 
@@ -68,10 +69,12 @@ func (cmd *ClusterList) Execute(args []string) (err error) {
 	}
 	// Add role (admin, team member ...)
 	// Add star for current cluster
-	hdr := []string{"CLUSTER", "VCPUS", "MEMORY", "PODS"}
+	hdr := []string{"ID", "CLUSTER NAME", "VCPUS", "MEMORY", "PODS"}
 	rows := [][]string{}
-	for _, cluster := range clusters.Clusters {
+	for x, cluster := range clusters.Clusters {
+		id := strconv.Itoa(x + 1)
 		rows = append(rows, []string{
+			id,
 			cluster.Name,
 			fmt.Sprintf("%.1f/%.1f", cluster.Usage.CPU, cluster.Capacity.CPU),
 			fmt.Sprintf("%s/%s", humanize.Bytes(uint64(cluster.Usage.Memory)), humanize.Bytes(uint64(cluster.Capacity.Memory))),

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -1,0 +1,26 @@
+package kubeconfig
+
+import (
+	"path/filepath"
+
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/pkg/errors"
+)
+
+// GetPath returns the expanded and normalized kube config path
+func GetPath(kubeConfig string) (string, error) {
+	hdir, err := homedir.Dir()
+	if err != nil {
+		return "", err
+	}
+	if kubeConfig == "" {
+		kubeConfig = filepath.Join(hdir, ".kube", "config")
+	}
+	kubeConfig, err = homedir.Expand(kubeConfig)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to expand home directory in kube config file path")
+	}
+	//Normalize all slashes to native platform slashes (e.g. / to \ on Windows)
+	kubeConfig = filepath.FromSlash(kubeConfig)
+	return kubeConfig, nil
+}

--- a/pkg/populator/generic.go
+++ b/pkg/populator/generic.go
@@ -20,16 +20,12 @@ type GenericPopulator struct {
 	// kubeConfigFile is the path where the kube config is stored
 	// Only access this with atomic ops
 	kubeConfigFile atomic.Value
-	homedir        string
 	cluster        *v1payload.GetClusterOutput
-	client         *Client
 }
 
-func newGeneric(c *Client, kubeConfigFile, homedir string, cluster *v1payload.GetClusterOutput) *GenericPopulator {
+func newGeneric(kubeConfigFile string, cluster *v1payload.GetClusterOutput) *GenericPopulator {
 	o := &GenericPopulator{
 		cluster: cluster,
-		homedir: homedir,
-		client:  c,
 	}
 	o.kubeConfigFile.Store(kubeConfigFile)
 	return o

--- a/pkg/populator/populator.go
+++ b/pkg/populator/populator.go
@@ -17,11 +17,11 @@ import (
 )
 
 //New instantiates a new P interface using the conf parameter. It can return a env, endpoint or oidc populator.
-func New(c *Client, conf, kubeConfigFile, homedir string, cluster *v1payload.GetClusterOutput) (P, error) {
+func New(conf, kubeConfigFile string, cluster *v1payload.GetClusterOutput) (P, error) {
 	switch conf {
 	case "generic":
 		// TO BE UPDATED
-		return newGeneric(c, kubeConfigFile, homedir, cluster), nil
+		return newGeneric(kubeConfigFile, cluster), nil
 	case "endpoint":
 		return newEndpoint(kubeConfigFile), nil
 	case "env":

--- a/pkg/populator/types.go
+++ b/pkg/populator/types.go
@@ -14,17 +14,6 @@ type P interface {
 	RemoveConfig(string) error
 }
 
-// Client provides necessary information to successfully use OIDC
-type Client struct {
-	// TODO CLEANING
-	// Secret necessary for OpenID connect
-	Secret string
-	// ID is a client id that all tokens must be issued for.
-	ID string
-	// IDPIssuerURL is the URL of the provider which allows the API server to discover public signing keys.
-	IDPIssuerURL string
-}
-
 // Context information
 type Context struct {
 	Name      string `long:"context" description:"context to use for this configuration"`


### PR DESCRIPTION
It is now possible to set a default cluster using its name or its identifier:
![image](https://user-images.githubusercontent.com/7657393/40369880-44659e4a-5ddf-11e8-9175-a5cc2df282e7.png)

This was done :
- to help people to set a default cluster if a name is too complex
- to avoid weird situation where a cluster doesn't have a name 