### PR TITLE
update error handling logic for flexvolume unmount

### DIFF
--- a/pkg/transfer/archiver/tar_archiver.go
+++ b/pkg/transfer/archiver/tar_archiver.go
@@ -127,8 +127,7 @@ func (a *TarArchiver) indexFS(path string, fn func(p string, fi os.FileInfo, err
 	return nil
 }
 
-//Archive will archive a directory at 'path' into readable objects 'r' and calls 'fn' for each
-func (a *TarArchiver) Archive(ctx context.Context, path string, rep Reporter, fn func(k string, r io.ReadSeeker, nbytes int64) error) (err error) {
+func checkValidDir(path string) (err error) {
 	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -137,6 +136,7 @@ func (a *TarArchiver) Archive(ctx context.Context, path string, rep Reporter, fn
 
 		return err
 	}
+	defer f.Close()
 	if info, err := os.Stat(path); !info.IsDir() {
 		if err != nil {
 			return err
@@ -147,6 +147,15 @@ func (a *TarArchiver) Archive(ctx context.Context, path string, rep Reporter, fn
 	if len(names) == 0 {
 		return ErrEmptyDirectory
 	}
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+//Archive will archive a directory at 'path' into readable objects 'r' and calls 'fn' for each
+func (a *TarArchiver) Archive(ctx context.Context, path string, rep Reporter, fn func(k string, r io.ReadSeeker, nbytes int64) error) (err error) {
+	err = checkValidDir(path)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This pull request should mitigate the issue #407:
- before, if there was an error during the unmount, it was trying to delete as much as possible, but the overlayFS was still mounted.
- during the archiving process, the directory was opened but never closed. This could cause the unmount to fail as the resources were marked as busy.
