### PR TITLE
Update default resource request values

### DIFF
--- a/cmd/job_run.go
+++ b/cmd/job_run.go
@@ -21,8 +21,8 @@ import (
 type JobRun struct {
 	Name       string   `long:"name" short:"n" description:"assign a name to the job"`
 	Env        []string `long:"env" short:"e" description:"environment variables to use"`
-	Memory     string   `long:"memory" short:"m" description:"memory to use for this job, expressed in gigabytes" default:"3"`
-	VCPU       string   `long:"vcpu" description:"number of vcpus to use for this job" default:"2"`
+	Memory     string   `long:"memory" short:"m" description:"memory to use for this job, expressed in gigabytes" default:"1"`
+	VCPU       string   `long:"vcpu" description:"number of vcpus to use for this job" default:"1"`
 	Inputs     []string `long:"input" description:"specify one or more inputs that will be used for the job using the following format: <DIR|DATASET_NAME>:<JOB_DIR>"`
 	Outputs    []string `long:"output" description:"specify one or more output folders that will be stored as datasets after the job is finished using the following format: <DATASET_NAME>:<JOB_DIR>"`
 	Private    bool     `long:"private" description:"use this flag with a private image, a prompt will ask for your username and password of the repository that stores the image. If NERD_IMAGE_USERNAME and/or NERD_IMAGE_PASSWORD environment variables are set, those values are used instead."`


### PR DESCRIPTION
This pull request sets new default values for memory and vcpu requests when users start a job with `nerd job run`. The new values let users run their application on a private cluster even with the smallest node possible without thinking about the resource requests.